### PR TITLE
Load specific space on space open if needed

### DIFF
--- a/src/components/spaces/show/index.js
+++ b/src/components/spaces/show/index.js
@@ -30,6 +30,12 @@ export default class SpacesShow extends Component {
 
   state = {showSidebar: true}
 
+  componentWillMount() {
+    if (!this.props.denormalizedSpace) {
+      this.props.dispatch(spaceActions.fetchById(parseInt(this.props.spaceId)))
+    }
+  }
+
   onSave() {
     this.props.dispatch(spaceActions.update(parseInt(this.props.spaceId)))
   }

--- a/src/modules/spaces/actions.js
+++ b/src/modules/spaces/actions.js
@@ -76,6 +76,32 @@ export function fetch() {
   }
 }
 
+export function fetchById(id) {
+  const url = (rootUrl + 'spaces/' + id)
+
+  return function(dispatch, getState) {
+    const action = standardActionCreators.fetchStart();
+    dispatch(action)
+
+    const request = formattedRequest({
+      state: getState(),
+      requestParams: {
+        url,
+        method: 'GET',
+      }
+    })
+
+    request.done(space => {
+      const action = standardActionCreators.fetchSuccess([space])
+      dispatch(action)
+    })
+
+    request.fail((jqXHR, textStatus, errorThrown) => {
+      captureApiError('SpacesFetch', jqXHR, textStatus, errorThrown, {url})
+    })
+  }
+}
+
 export function create(object) {
   return function(dispatch, getState) {
     dispatch({ type: 'redux-form/START_SUBMIT', form: 'contact' })
@@ -94,6 +120,7 @@ export function create(object) {
     })
 
     request.done(data => {
+      debuggerk
       const action = standardActionCreators.createSuccess(data, cid)
       dispatch(action)
       app.router.history.navigate('/models/' + data.id)

--- a/src/modules/spaces/actions.js
+++ b/src/modules/spaces/actions.js
@@ -120,7 +120,6 @@ export function create(object) {
     })
 
     request.done(data => {
-      debuggerk
       const action = standardActionCreators.createSuccess(data, cid)
       dispatch(action)
       app.router.history.navigate('/models/' + data.id)


### PR DESCRIPTION
This is a quick fix for https://github.com/getguesstimate/guesstimate-app/issues/45

Basically, one big problem was that users going straight to specific models experienced a very slow response.  This loads that specific model in parallel (when needed), which is typically much faster.