### PR TITLE
Reduce autosave use, use ssl for api

### DIFF
--- a/src/components/distributions/editor/index.js
+++ b/src/components/distributions/editor/index.js
@@ -1,7 +1,7 @@
 import React, {Component, PropTypes} from 'react';
 import ReactDOM from 'react-dom'
 import { connect } from 'react-redux';
-import { createGuesstimateForm, changeGuesstimateForm, saveGuesstimateForm} from 'gModules/guesstimate_form/actions'
+import { createGuesstimateForm, changeGuesstimateForm, saveGuesstimateForm } from 'gModules/guesstimate_form/actions'
 import { changeMetricClickMode } from 'gModules/canvas_state/actions'
 import $ from 'jquery'
 import Icon from 'react-fa'
@@ -28,7 +28,8 @@ class GuesstimateForm extends Component{
   }
 
   state = {
-    showDistributionSelector: false
+    showDistributionSelector: false,
+    hasChanged: false
   }
 
   componentWillMount() {
@@ -70,6 +71,15 @@ class GuesstimateForm extends Component{
 
   _changeInput(input) {
     this._dispatchChange({input: input})
+    this.setState({hasChanged: true})
+  }
+
+  _handleBlur() {
+    this._switchMetricClickMode(false)
+
+    if (this.state.hasChanged){
+      this.props.dispatch(saveGuesstimateForm());
+    }
   }
 
   _switchMetricClickMode(inClick=true) {
@@ -98,7 +108,7 @@ class GuesstimateForm extends Component{
               metricFocus={metricFocus}
               onChange={this._changeInput.bind(this)}
               onFocus={() => {this._switchMetricClickMode.bind(this)(true)}}
-              onBlur={() => {this._switchMetricClickMode.bind(this)(false)}}
+              onBlur={this._handleBlur.bind(this)}
               ref='TextInput'
             />
             <GuesstimateTypeIcon

--- a/src/modules/guesstimate_form/actions.js
+++ b/src/modules/guesstimate_form/actions.js
@@ -21,7 +21,6 @@ export function changeGuesstimateForm(values) {
   return (dispatch, getState) => {
     dispatch(updateGuesstimateForm(values));
     dispatch(runFormSimulations(getState().guesstimateForm.metric));
-    dispatch(saveGuesstimateForm())
   };
 }
 

--- a/src/modules/search_spaces/actions.js
+++ b/src/modules/search_spaces/actions.js
@@ -8,7 +8,7 @@ export function fetch(query = '', options = {}) {
   if (options.user_id) {
     filters.numericFilters = `user_id=${options.user_id}`
   } else {
-    filters.numericFilters = `metric_count>1`
+    filters.numericFilters = `metric_count>2`
   }
 
   return (dispatch, getState) => {

--- a/src/server/guesstimate-api/constants.js
+++ b/src/server/guesstimate-api/constants.js
@@ -1,1 +1,1 @@
-export const rootUrl = (__API_ENV__ === 'development') ? 'http://localhost:4000/' : 'http://guesstimate.herokuapp.com/'
+export const rootUrl = (__API_ENV__ === 'development') ? 'http://localhost:4000/' : 'https://guesstimate.herokuapp.com/'


### PR DESCRIPTION
Instead of saving for each numeric keypress, save when that field is blurred.  

Also got ssl working for the heroku server (this was breaking for a bunch of people who used HTTPS everywhere).  