### PR TITLE
Get model & user information from Algolia, not server

### DIFF
--- a/src/components/users/show/index.js
+++ b/src/components/users/show/index.js
@@ -16,27 +16,29 @@ function mapStateToProps(state) {
 export default class UserShow extends Component{
   displayName: 'UserShow'
   render () {
-    const {users} = this.props
+    const {userId, users} = this.props
     let user = null
 
     if (users && users.length) {
-      user = this.props.users.find(u => u.id.toString() === this.props.userId.toString())
+      user = users.find(u => u.id.toString() === userId.toString())
     }
 
     return (
       <div className='userShow'>
-        {user &&
-          <GeneralSpaceIndex userId={user.id}>
-            <div className='main-user-tag'>
+        <GeneralSpaceIndex userId={userId}>
+          <div className='main-user-tag'>
+            {user &&
               <img
                   src={user.picture}
               />
-            </div>
-            <h2>
-              {user.name}
-            </h2>
-          </GeneralSpaceIndex>
-      }
+            }
+          </div>
+            {user &&
+              <h2>
+                {user.name}
+              </h2>
+            }
+        </GeneralSpaceIndex>
     </div>
     )
   }

--- a/src/modules/search_spaces/actions.js
+++ b/src/modules/search_spaces/actions.js
@@ -1,7 +1,8 @@
 import algoliasearch from 'algoliasearch'
 import {searchSpaceIndex} from '../../server/algolia/index.js'
 import {searchError} from 'lib/errors/index.js'
-import {fromSearch} from 'gModules/spaces/actions'
+import * as spaceActions from 'gModules/spaces/actions'
+import * as userActions from 'gModules/users/actions'
 
 export function fetch(query = '', options = {}) {
   let filters = {hitsPerPage: 20}
@@ -20,7 +21,8 @@ export function fetch(query = '', options = {}) {
       else {
         results.filters = filters
         dispatch({ type: 'SEARCH_SPACES_GET', response: results })
-        dispatch(fromSearch(results.hits))
+        dispatch(spaceActions.fromSearch(results.hits))
+        dispatch(userActions.fromSearch(results.hits))
       }
     })
   }
@@ -39,7 +41,8 @@ export function fetchNextPage() {
         searchError('AlgoliaFetchNextPage', error)
       } else {
         dispatch({ type: 'SEARCH_SPACES_NEXT_PAGE', response: results })
-        dispatch(fromSearch(results.hits))
+        dispatch(spaceActions.fromSearch(results.hits))
+        dispatch(userActions.fromSearch(results.hits))
       }
     })
   }

--- a/src/modules/search_spaces/actions.js
+++ b/src/modules/search_spaces/actions.js
@@ -1,6 +1,7 @@
 import algoliasearch from 'algoliasearch'
 import {searchSpaceIndex} from '../../server/algolia/index.js'
 import {searchError} from 'lib/errors/index.js'
+import {fromSearch} from 'gModules/spaces/actions'
 
 export function fetch(query = '', options = {}) {
   let filters = {hitsPerPage: 20}
@@ -19,6 +20,7 @@ export function fetch(query = '', options = {}) {
       else {
         results.filters = filters
         dispatch({ type: 'SEARCH_SPACES_GET', response: results })
+        dispatch(fromSearch(results.hits))
       }
     })
   }
@@ -37,6 +39,7 @@ export function fetchNextPage() {
         searchError('AlgoliaFetchNextPage', error)
       } else {
         dispatch({ type: 'SEARCH_SPACES_NEXT_PAGE', response: results })
+        dispatch(fromSearch(results.hits))
       }
     })
   }

--- a/src/modules/spaces/actions.js
+++ b/src/modules/spaces/actions.js
@@ -52,27 +52,11 @@ export function destroy(object) {
   }
 }
 
-export function fetch() {
-  return function(dispatch, getState) {
-    const action = standardActionCreators.fetchStart();
+export function fromSearch(data) {
+  return function(dispatch) {
+    const formatted = data.map(d => _.pick(d, ['id', 'name', 'description', 'user_id', 'updated_at', 'metric_count']))
+    const action = standardActionCreators.fetchSuccess(formatted)
     dispatch(action)
-
-    const request = formattedRequest({
-      state: getState(),
-      requestParams: {
-        url: (rootUrl + 'spaces'),
-        method: 'GET',
-      }
-    })
-
-    request.done(data => {
-      const action = standardActionCreators.fetchSuccess(data)
-      dispatch(action)
-    })
-
-    request.fail((jqXHR, textStatus, errorThrown) => {
-      captureApiError('SpacesFetch', jqXHR, textStatus, errorThrown, {url: (rootUrl+'spaces')})
-    })
   }
 }
 

--- a/src/modules/spaces/actions.js
+++ b/src/modules/spaces/actions.js
@@ -7,6 +7,7 @@ import app from 'ampersand-app'
 import {rootUrl} from 'servers/guesstimate-api/constants.js'
 import {captureApiError} from 'lib/errors/index.js'
 import {changeSaveState} from 'gModules/canvas_state/actions.js'
+import * as userActions from 'gModules/users/actions.js'
 
 let standardActionCreators = actionCreatorsFor('spaces');
 
@@ -78,6 +79,11 @@ export function fetchById(id) {
     request.done(space => {
       const action = standardActionCreators.fetchSuccess([space])
       dispatch(action)
+
+      const users = getState().users
+      const user_id = space.user_id
+      const has_user = !!(users.find(e => e.id === user_id))
+      if (!has_user) { dispatch(userActions.fetchById(user_id)) }
     })
 
     request.fail((jqXHR, textStatus, errorThrown) => {

--- a/src/modules/users/actions.js
+++ b/src/modules/users/actions.js
@@ -59,6 +59,34 @@ export function fetch(params = {}) {
   }
 }
 
+export function fetchById(id) {
+  const url = (rootUrl + 'users/' + id)
+
+  return function(dispatch, getState) {
+    const action = standardActionCreators.fetchStart();
+    dispatch(action)
+
+    const request = formattedRequest({
+      state: getState(),
+      requestParams: {
+        url,
+        method: 'GET',
+      }
+    })
+
+    request.done(data => {
+      const action = standardActionCreators.fetchSuccess(data)
+      dispatch(action)
+
+    })
+
+    request.fail((jqXHR, textStatus, errorThrown) => {
+      dispatch(displayErrorsActions.newError())
+      captureApiError('UsersFetch', jqXHR, textStatus, errorThrown, {url})
+    })
+  }
+}
+
 export function fromSearch(spaces) {
   return function(dispatch) {
     const users = spaces.map(s => s.user_info)

--- a/src/modules/users/actions.js
+++ b/src/modules/users/actions.js
@@ -59,6 +59,15 @@ export function fetch(params = {}) {
   }
 }
 
+export function fromSearch(spaces) {
+  return function(dispatch) {
+    const users = spaces.map(s => s.user_info)
+    const formatted = users.map(d => _.pick(d, ['auth0_id', 'id', 'name', 'picture']))
+    const action = standardActionCreators.fetchSuccess(formatted)
+    dispatch(action)
+  }
+}
+
 export function create(object) {
   return function(dispatch, getState) {
 

--- a/src/routes/layouts/application/index.js
+++ b/src/routes/layouts/application/index.js
@@ -32,7 +32,6 @@ export default class extends Component{
 
   componentDidMount() {
     this.props.dispatch(meActions.init())
-    this.props.dispatch(userActions.fetch())
   }
 
   _registerUser(){

--- a/src/routes/layouts/application/index.js
+++ b/src/routes/layouts/application/index.js
@@ -32,7 +32,6 @@ export default class extends Component{
 
   componentDidMount() {
     this.props.dispatch(meActions.init())
-    this.props.dispatch(spaceActions.fetch())
     this.props.dispatch(userActions.fetch())
   }
 


### PR DESCRIPTION
Previous all models and users were loaded into the browser for each request.  Most of this was redundant, because the important stuff was in the Algolia search results.  

Here I used the Algolia search results for the models and users.  This took a bit of fine tuning, but wasn't too bad. 

This addresses this issue: https://github.com/getguesstimate/guesstimate-app/issues/45