### PR TITLE
When model graph is changed, only update graph

### DIFF
--- a/src/components/spaces/canvas/index.js
+++ b/src/components/spaces/canvas/index.js
@@ -91,7 +91,6 @@ export default class CanvasSpace extends Component{
     this.props.dispatch(changeSelect(next))
   }
 
-
   renderMetric(metric) {
     const {location} = metric
     return (

--- a/src/modules/guesstimates/actions.js
+++ b/src/modules/guesstimates/actions.js
@@ -2,16 +2,16 @@ import {runMetricSimulations} from 'gModules/simulations/actions.js'
 import * as spaceActions from 'gModules/spaces/actions.js'
 import engine from 'gEngine/engine'
 
-function registerChange(dispatch, getState, metricId) {
+function registerGraphChange(dispatch, getState, metricId) {
   const metric = engine.metric.get(getState().metrics, metricId)
   const spaceId =  _.get(metric, 'space')
-  spaceId && dispatch(spaceActions.registerChange(spaceId));
+  spaceId && dispatch(spaceActions.registerGraphChange(spaceId));
 }
 
 export function changeGuesstimate(metricId, values) {
   return (dispatch, getState) => {
     let relevantKeys = ['input', 'metric', 'guesstimateType', 'description']
     dispatch({ type: 'CHANGE_GUESSTIMATE', metricId, values: _.pick(values, ...relevantKeys) })
-    registerChange(dispatch, getState, metricId)
+    registerGraphChange(dispatch, getState, metricId)
   };
 }

--- a/src/modules/metrics/actions.js
+++ b/src/modules/metrics/actions.js
@@ -6,8 +6,8 @@ function findSpaceId(getState, metricId) {
   return _.get(metric, 'space')
 }
 
-function registerChange(dispatch, spaceId) {
-  spaceId && dispatch(spaceActions.registerChange(spaceId));
+function registerGraphChange(dispatch, spaceId) {
+  spaceId && dispatch(spaceActions.registerGraphChange(spaceId));
 }
 
 export function addMetric(item) {
@@ -26,13 +26,13 @@ export function removeMetric(id) {
     const spaceId = findSpaceId(getState, id)
 
     dispatch({ type: 'REMOVE_METRIC', item: {id: id}});
-    registerChange(dispatch, spaceId)
+    registerGraphChange(dispatch, spaceId)
   }
 }
 
 export function changeMetric(item) {
   return (dispatch, getState) => {
     dispatch({ type: 'CHANGE_METRIC', item });
-    registerChange(dispatch, findSpaceId(getState, item.id))
+    registerGraphChange(dispatch, findSpaceId(getState, item.id))
   }
 }


### PR DESCRIPTION
This is to eventually make sure that the server only updates with Algolia when non-graph items are changed.