### PR TITLE
Fix replication bug

### DIFF
--- a/src/components/lib/grid/edges.js
+++ b/src/components/lib/grid/edges.js
@@ -52,8 +52,10 @@ export default class Edges extends Component {
   }
 
   render() {
-    const {columnWidth, containerHeight, containerWidth, edges, rowHeights} = this.props
-    const showEdges = !!(_.get(edges, 'length') && _.get(rowHeights, 'length') && columnWidth)
+    const {columnWidth, containerHeight, containerWidth, rowHeights} = this.props
+    let {edges} = (this.props)
+    edges = _.uniqBy(edges, e => JSON.stringify(e))
+    let showEdges = !!(_.get(edges, 'length') && _.get(rowHeights, 'length') && columnWidth)
     return (
       <div className='GiantGrid--Arrows'>
       {(edges.length > 0) &&

--- a/src/modules/guesstimates/reducer-test.js
+++ b/src/modules/guesstimates/reducer-test.js
@@ -1,0 +1,44 @@
+import reducer from './reducer.js'
+
+describe.only('guesstimatesReducer', () => {
+
+  describe.only('#SPACES_FETCH_SUCCESS', () => {
+    const spaces = [
+      {
+        graph: {
+          metrics: [],
+          guesstimates: [
+            {metric: '1', guesstimateType: 'NONE', input: ''},
+            {metric: '2', guesstimateType: 'NONE', input: ''},
+            {metric: '2', guesstimateType: 'POINT', input: '3'}
+          ]
+        }
+      }
+    ]
+
+    it(`removes redundant metrics`, () => {
+      const newGuesstimates = reducer([], {type: 'SPACES_FETCH_SUCCESS', records: spaces })
+      expect(newGuesstimates.length).to.equal(2)
+      expect(newGuesstimates[1].input).to.equal('3')
+    })
+  });
+
+  describe('#ADD_METRIC', () => {
+    const guesstimates =  [
+      {metric: '1', guesstimateType: 'NONE', input: ''},
+      {metric: '2', guesstimateType: 'POINT', input: '3'}
+    ]
+
+    it(`correctly adds new element`, () => {
+      const newGuesstimates = reducer(guesstimates, {type: 'ADD_METRIC', item: {id: '3'}})
+      expect(newGuesstimates.length).to.equal(3)
+      expect(newGuesstimates[2].metric).to.equal('3')
+    })
+
+    it(`correctly adds a redundant element`, () => {
+      const newGuesstimates = reducer(guesstimates, {type: 'ADD_METRIC', item: {id: '2'}})
+      expect(newGuesstimates.length).to.equal(2)
+      expect(newGuesstimates[1].input).to.equal('')
+    })
+  });
+})

--- a/src/modules/guesstimates/reducer.js
+++ b/src/modules/guesstimates/reducer.js
@@ -1,7 +1,7 @@
 import engine from 'gEngine/engine'
 
 function uniq(items) {
-  return _.uniqBy(items, 'metric')
+  return _.uniqBy(items.reverse(), 'metric').reverse()
 }
 
 export default function guesstimates(state = [], action) {

--- a/src/modules/guesstimates/reducer.js
+++ b/src/modules/guesstimates/reducer.js
@@ -1,23 +1,24 @@
 import engine from 'gEngine/engine'
 
+function uniq(items) {
+  return _.uniqBy(items, 'metric')
+}
+
 export default function guesstimates(state = [], action) {
   switch (action.type) {
   case 'SPACES_FETCH_SUCCESS':
     let newGuesstimates = _.flatten(action.records.map(e => _.get(e, 'graph.guesstimates'))).filter(e => e)
-    return [...state, ...newGuesstimates]
+    return uniq([...state, ...newGuesstimates])
   case 'ADD_METRIC':
-    return [...state, {metric: action.item.id, input: '', guesstimateType: 'NONE', description: ''}]
+    return uniq([...state, {metric: action.item.id, input: '', guesstimateType: 'NONE', description: ''}])
   case 'REMOVE_METRIC':
     return state.filter(y => y.metric !== action.item.id)
   case 'CHANGE_GUESSTIMATE':
     const i = state.findIndex(y => y.metric === action.values.metric);
+    const newItem = engine.guesstimate.format(action.values)
     if (i !== -1) {
-      const newState = [
-        ...state.slice(0, i),
-        engine.guesstimate.format(action.values),
-        ...state.slice(i+1, state.length)
-      ];
-      return newState
+      const newState = [ ...state.slice(0, i), newItem, ...state.slice(i+1, state.length) ];
+      return uniq(newState)
     }
   default:
     return state;

--- a/src/modules/metrics/reducer-test.js
+++ b/src/modules/metrics/reducer-test.js
@@ -1,6 +1,6 @@
 import metricsReducer from './reducer.js'
 
-describe.only('metrics', () => {
+describe('metrics', () => {
 
   describe('#SPACES_FETCH_SUCCESS', () => {
     const metrics = [

--- a/src/modules/metrics/reducer-test.js
+++ b/src/modules/metrics/reducer-test.js
@@ -1,0 +1,55 @@
+import metricsReducer from './reducer.js'
+
+describe.only('metrics', () => {
+
+  describe('#SPACES_FETCH_SUCCESS', () => {
+    const metrics = [
+      {id: '1', name: 'foo1'},
+      {id: '2', name: 'foo2'},
+      {id: '2', name: 'foo3'}
+    ]
+
+    it(`removes redundant metrics`, () => {
+      const newMetrics = metricsReducer([], {type: 'SPACES_FETCH_SUCCESS', records: [{graph: {metrics}}] })
+      expect(newMetrics.length).to.equal(2)
+      expect(newMetrics[1].name).to.equal('foo3')
+    })
+  });
+
+  describe('#ADD_METRIC', () => {
+    const metrics = [
+      {id: '1', name: 'foo1'},
+      {id: '2', name: 'foo2'}
+    ]
+
+    it(`correctly adds new element`, () => {
+      const newMetric = {id: '3', name: 'foo3'}
+      const newMetrics = metricsReducer(metrics, {type: 'ADD_METRIC', item: newMetric})
+      expect(newMetrics.length).to.equal(3)
+      expect(newMetrics[2].id).to.equal('3')
+    })
+
+    it(`correctly adds a redundant element`, () => {
+      const newMetric = {id: '2', name: 'foo3'}
+      const newMetrics = metricsReducer(metrics, {type: 'ADD_METRIC', item: newMetric})
+      expect(newMetrics.length).to.equal(2)
+      expect(newMetrics[1].name).to.equal('foo3')
+    })
+  });
+
+  describe('#CHANGE_METRIC', () => {
+    const metrics = [
+      {id: '1', name: 'foo1'},
+      {id: '2', name: 'foo2'},
+      {id: '3', name: 'foo3'},
+    ]
+
+    it(`changes metric`, () => {
+      const changedMetric = {id: '2', name: 'bar2'}
+      const newMetrics = metricsReducer(metrics, {type: 'CHANGE_METRIC', item: changedMetric})
+      expect(newMetrics.length).to.equal(3)
+      expect(newMetrics[1].name).to.equal('bar2')
+    })
+  });
+
+})

--- a/src/modules/metrics/reducer.js
+++ b/src/modules/metrics/reducer.js
@@ -1,5 +1,5 @@
 function uniq(items) {
-  return _.uniqBy(items, 'id')
+  return _.uniqBy(items.reverse(), 'id').reverse()
 }
 
 export default function metrics(state = [], action) {
@@ -15,11 +15,11 @@ export default function metrics(state = [], action) {
     const i = state.findIndex(y => y.id === action.item.id);
     const newItem = Object.assign(state[i], action.item);
     if (i !== -1) {
-      return uniq([
+      return [
         ...state.slice(0, i),
         newItem,
         ...state.slice(i+1, state.length)
-      ]);
+      ];
     }
   default:
     return state

--- a/src/modules/metrics/reducer.js
+++ b/src/modules/metrics/reducer.js
@@ -1,20 +1,25 @@
+function uniq(items) {
+  return _.uniqBy(items, 'id')
+}
+
 export default function metrics(state = [], action) {
   switch (action.type) {
   case 'SPACES_FETCH_SUCCESS':
     let newMetrics = _.flatten(action.records.map(e => _.get(e, 'graph.metrics'))).filter(e => e)
-    return [...state, ...newMetrics]
+    return uniq([...state, ...newMetrics])
   case 'ADD_METRIC':
-    return [...state, action.item]
+    return uniq([...state, action.item])
   case 'REMOVE_METRIC':
     return state.filter(y => y.id !== action.item.id)
   case 'CHANGE_METRIC':
     const i = state.findIndex(y => y.id === action.item.id);
+    const newItem = Object.assign(state[i], action.item);
     if (i !== -1) {
-      return [
+      return uniq([
         ...state.slice(0, i),
-        Object.assign(state[i], action.item),
+        newItem,
         ...state.slice(i+1, state.length)
-      ];
+      ]);
     }
   default:
     return state


### PR DESCRIPTION
This is one fix for the following bug.  It seems like there were a few problems here:

1) Some metrics were being created multiple times or were copied for some reason.
2) New guesstimates (inputs for metrics) were created on loop. 

I'm not sure exactly what caused these, but the reducers definitely shouldn't have allowed for this to create gigantic models of the same metrics and guesstimates.  I've solved the main issue here by enforcing uniqueness for metrics and guesstimates within models.  Later on we could look at the other two issues directly (this may take some time to reproduce).

Also, this is not a fix for the fact that some metrics are so huge that they won't actually get loaded.  Ideally there would be a back end fix for this; we would have a script to go through every single item and fix it.  This will take some work, so I'll get to this later on.

https://github.com/getguesstimate/guesstimate-app/issues/85