### PR TITLE
Arrows should take 100% width

### DIFF
--- a/src/components/lib/grid/edge-container.js
+++ b/src/components/lib/grid/edge-container.js
@@ -33,7 +33,7 @@ export default class EdgeContainer extends Component {
   }
 
   render() {
-    const {edges, containerWidth} = this.props
+    const {edges} = this.props
     const {columnWidth} = this.state
 
     const rowHeights = this.props.rowHeights
@@ -42,7 +42,6 @@ export default class EdgeContainer extends Component {
       <Edges
           columnWidth={columnWidth}
           containerHeight={containerHeight}
-          containerWidth={containerWidth}
           edges={edges}
           rowHeights={rowHeights}
       />

--- a/src/components/lib/grid/edges.js
+++ b/src/components/lib/grid/edges.js
@@ -11,7 +11,6 @@ export default class Edges extends Component {
   static propTypes = {
     columnWidth: PropTypes.number,
     containerHeight: PropTypes.number,
-    containerWidth: PropTypes.number,
     edges: PropTypes.array.isRequired,
     rowHeights: PropTypes.array.isRequired,
   }
@@ -52,7 +51,7 @@ export default class Edges extends Component {
   }
 
   render() {
-    const {columnWidth, containerHeight, containerWidth, rowHeights} = this.props
+    const {columnWidth, containerHeight, rowHeights} = this.props
     let {edges} = (this.props)
     edges = _.uniqBy(edges, e => JSON.stringify(e))
     let showEdges = !!(_.get(edges, 'length') && _.get(rowHeights, 'length') && columnWidth)
@@ -62,7 +61,7 @@ export default class Edges extends Component {
         <svg
             className='edge'
             height={containerHeight}
-            width={containerWidth}
+            width={'100%'}
         >
           <defs key={'defs'} dangerouslySetInnerHTML={{__html: this.defs()}}/>
           {showEdges &&

--- a/src/components/lib/grid/grid.css
+++ b/src/components/lib/grid/grid.css
@@ -122,10 +122,6 @@ svg.edge  path.basic-arrow {
   stroke-dasharray:'5,5';
 }
 
-.GiantGrid--Arrows {
-   width: 100%;
-}
-
 .arrow {
   stroke-width: 0;
   fill: $blue-1;

--- a/src/components/spaces/show/style.css
+++ b/src/components/spaces/show/style.css
@@ -12,6 +12,7 @@
   display: flex;
   flex: 1;
   max-height: 100%;
+  overflow: auto;
 }
 
 .hero-unit {


### PR DESCRIPTION
This addresses this issue: https://github.com/getguesstimate/guesstimate-app/issues/91