### PR TITLE
More distributions button, closes #171

### DIFF
--- a/src/components/distributions/editor/TextForm/DistributionSelector.js
+++ b/src/components/distributions/editor/TextForm/DistributionSelector.js
@@ -8,6 +8,7 @@ import ExponentialImage from 'assets/distribution-icons/exponential.png'
 import PointImage from 'assets/distribution-icons/point.png'
 import UniformImage from 'assets/distribution-icons/uniform.png'
 import {Guesstimator} from 'lib/guesstimator/index.js'
+import * as elev from 'server/elev/index.js'
 
 class DistributionIcon extends Component{
   _handleSubmit() {
@@ -28,11 +29,21 @@ class DistributionIcon extends Component{
 }
 
 export default class DistributionSelector extends Component{
+  _handleShowMore() {
+    elev.open(elev.ADDITIONAL_DISTRIBUTIONS)
+  }
+
   render() {
     const {selected} = this.props
     return (
       <div className='DistributionSelector'>
         <hr/>
+        <a
+          className='more-distributions'
+          onMouseDown={this._handleShowMore.bind(this)}
+        >
+          {'More'}
+        </a>
         <div className='DistributionList'>
           {['NORMAL', 'UNIFORM', 'LOGNORMAL'].map(type => {
             const isSelected = (selected === type)

--- a/src/components/distributions/editor/style.css
+++ b/src/components/distributions/editor/style.css
@@ -30,6 +30,16 @@
   border-top: 1px solid $grey-1;
 }
 
+.DistributionSelector .more-distributions{
+  float: left;
+  cursor: pointer;
+  text-decoration: underline;
+  padding-left: 2px;
+  padding-top: 9px;
+  font-size: 16px;
+  color: #848484;
+}
+
 .GuesstimateForm .DistributionIcon.DistributionIcon{
   font-size: 1em;
   padding-top: 2px;

--- a/src/components/distributions/summary/index.js
+++ b/src/components/distributions/summary/index.js
@@ -2,8 +2,6 @@ import React, {Component, PropTypes} from 'react';
 import numeral from 'numeral'
 import numberShow from 'lib/numberShower/numberShower.js'
 import './style.css'
-
-import _ from 'lodash'
 import ShowIf from 'gComponents/utility/showIf';
 
 function formatStat(n){
@@ -38,7 +36,10 @@ class DistributionSummarySmall extends Component{
     let stats = this.props.stats;
     let {mean, stdev, percentiles} = stats
     let range = null
-    if (_.isObject(percentiles)){ range = (percentiles[95] - mean)}
+    if (_.isObject(percentiles)) {
+      const [lowRange, highRange] = [(mean - percentiles[5]), (percentiles[95] - mean)]
+      range = (highRange + lowRange) / 2
+    }
     return (
       <div className="DistributionSummary">
         <PrecisionNumber value={mean}/>

--- a/src/server/elev/index.js
+++ b/src/server/elev/index.js
@@ -1,6 +1,7 @@
 export const GUESSTIMATE_TYPES = 34126
 export const EXISTING_FUNCTIONS = 34121
 export const CONFIDENCE_INTERVALS = 34205
+export const ADDITIONAL_DISTRIBUTIONS = 50927
 
 export function open(id) {
   window._elev.openArticle(id);

--- a/src/styles/variables.css
+++ b/src/styles/variables.css
@@ -11,6 +11,7 @@ $grey-2: #7089a9;
 $grey-4: #aaa;
 $grey-5: #f5f8fd;
 $grey-666: #666;
+$grey-999: #999;
 $grey-eee: #eee;
 
 $purple-1: #7970A9;


### PR DESCRIPTION
This did two things. 
- Add 'more' link when a metric card is expanded.
- Use the average percentile range instead of only using the high value.  This is important for all asymmetric distributions.

![image](https://cloud.githubusercontent.com/assets/377065/13690827/8d0f19c0-e6e8-11e5-80fb-4ad1a37ac3ed.png)
