### PR TITLE
Making name not required in metric card as metrics are often unnamed …

### DIFF
--- a/src/components/metrics/card/name/index.js
+++ b/src/components/metrics/card/name/index.js
@@ -7,7 +7,7 @@ export default class MetricName extends Component {
   displayName: 'MetricName'
 
   static propTypes = {
-    name: PropTypes.string.isRequired,
+    name: PropTypes.string,
     isSelected: PropTypes.bool.isRequired,
     onChange: PropTypes.func.isRequired,
   }


### PR DESCRIPTION
…(client giving errors about this).