### PR TITLE
Cuts off low density tails of the histogram. Closes 219.

### DIFF
--- a/src/components/lib/histogram.js
+++ b/src/components/lib/histogram.js
@@ -1,7 +1,5 @@
 var React = require("react");
 var d3 = require("d3");
-
-import {Stats} from 'fast-stats'
 import numberShow from 'lib/numberShower/numberShower.js'
 
 function getYScale(data, height) {
@@ -17,15 +15,22 @@ function getXScale(data, width) {
     nice();
 }
 
+// Computes the average of an array of numbers. If the array is empty, returns 1.
 function avg(arr) {
-  return arr.reduce((a,b)=>a+b)/arr.length
+  return arr.length > 0 ? arr.reduce((a,b)=>a+b)/arr.length : 1
 }
 
+// Computes min(|a|,|b|)/max(|a|,|b|).
 function fractionLT1(a,b) {
   return Math.min(Math.abs(a),Math.abs(b))/Math.max(Math.abs(a),Math.abs(b))
 }
 
 function filterData(inputData, cutOff) {
+  // We can't filter that intelligently for small sample sets, so we don't bother.
+  if (inputData.length < 2000) {
+    return inputData
+  }
+
   let outputData = inputData // A copy for immutability
   outputData.sort((a,b) => a-b) // Sort the data from min -> max.
 
@@ -41,12 +46,12 @@ function filterData(inputData, cutOff) {
   }
 
   // Filter Right
-  right = outputData.slice(-bucketSize)
   left = outputData.slice(-2*bucketSize,-bucketSize)
+  right = outputData.slice(-bucketSize)
   while (fractionLT1(avg(left),avg(right)) < cutOff) {
     outputData = outputData.slice(0,-bucketSize)
-    right = outputData.slice(-bucketSize)
     left = outputData.slice(-2*bucketSize,-bucketSize)
+    right = outputData.slice(-bucketSize)
   }
 
   return outputData
@@ -70,7 +75,7 @@ export default class Histogram extends React.Component {
     bottom: 30,
     left: 5,
     bins: 40,
-    cutOffRatio: 0.99,
+    cutOffRatio: 0, // By default cut off nothing.
   };
 
   render() {

--- a/src/components/lib/histogram.js
+++ b/src/components/lib/histogram.js
@@ -36,7 +36,7 @@ function filterLowDensityPoints(inputData, cutOffRatio) {
     return inputData
   }
 
-  let outputData = Object.assign({}, inputData) // A copy for immutability
+  let outputData = Object.assign([], inputData) // A copy for immutability
   outputData.sort((a,b) => a-b) // Sort the data from min -> max.
 
   const bucketSize = outputData.length / 1000 // Grab data in 0.1% chunks.

--- a/src/components/metrics/card/index.js
+++ b/src/components/metrics/card/index.js
@@ -187,6 +187,7 @@ class MetricCard extends Component {
           {(metricCardView !== 'basic') && showSimulation &&
             <Histogram height={(metricCardView === 'scientific') ? 75 : 30}
                 simulation={metric.simulation}
+                cutOffRatio={0.995}
             />
           }
 

--- a/src/components/metrics/modal/index.js
+++ b/src/components/metrics/modal/index.js
@@ -79,7 +79,7 @@ export default class MetricModal extends Component {
       <div className='metricModal'>
         <div className='container top'>
           <div className='histogram'>
-            <Histogram height={150} top={0} bottom={0} bins={100} widthPercent={80}
+            <Histogram height={150} top={0} bottom={0} bins={100} widthPercent={80} cutOffRatio={0.98}
                 simulation={metric.simulation}
             />
           </div>

--- a/src/components/simulations/histogram/index.js
+++ b/src/components/simulations/histogram/index.js
@@ -10,6 +10,7 @@ class SimulationHistogram extends Component{
     containerWidth: PT.number,
     height: PT.number,
     simulation: PT.object,
+    cutOffRatio: PT.number,
   }
 
   static defaultProps = {
@@ -36,6 +37,7 @@ class SimulationHistogram extends Component{
           width={(this.props.containerWidth + 5) * this.props.widthPercent / 100}
           bottom={20}
           bins={this.props.bins}
+          cutOffRatio={this.props.cutOffRatio}
       />
     )
   };


### PR DESCRIPTION
This works for heavy tailed distributions, either symmetric or asymmetric. It's deployed to stage now. 

This will not work for anything with significant bimodality.

For uniform & normal distributions over ranges on the order of 10^150 or greater, card histograms don't render but the model remains accessible and usable (semi-graceful failure):
![drunken-swan](https://cloud.githubusercontent.com/assets/470751/14230950/538e349a-f923-11e5-8cc9-6c5ab96d85c1.png)
(though even in these cases the modal still renders the distribution.

For lognormals, things get that bad after ranges on the order of 10^10 or greater:
![drunken-swan-log](https://cloud.githubusercontent.com/assets/470751/14230967/4380c594-f924-11e5-997d-fdca67e7b46e.png)

If those range sizes are unacceptable, we can try to add edge case logic for them somehow.