### PR TITLE
Changed recursive search algorithms to iterative and exit early upon self encounters to prevent infinite loops.

### DIFF
--- a/src/lib/basic_graph/basic-graph.js
+++ b/src/lib/basic_graph/basic-graph.js
@@ -13,7 +13,6 @@ export default class BasicGraph {
     return new BasicGraph(itemSubset, edgeSubset)
   }
 
-  // TODO(Question for Ozzie): Why aren't these passing oneLevel down? Seems like this shouldn't work...
   children(id, oneLevel=true) {
     return this.childrenIds(id, oneLevel).map(e => this.nodes.find(m => m.id === e))
   }

--- a/src/lib/basic_graph/basic-graph.js
+++ b/src/lib/basic_graph/basic-graph.js
@@ -15,7 +15,7 @@ export default class BasicGraph {
 
   // TODO(Question for Ozzie): Why aren't these passing oneLevel down? Seems like this shouldn't work...
   children(id, oneLevel=true) {
-    return this.childrenIds(id).map(e => this.nodes.find(m => m.id === e))
+    return this.childrenIds(id, oneLevel).map(e => this.nodes.find(m => m.id === e))
   }
 
   directParents(id) {

--- a/src/lib/basic_graph/basic-graph.js
+++ b/src/lib/basic_graph/basic-graph.js
@@ -13,8 +13,13 @@ export default class BasicGraph {
     return new BasicGraph(itemSubset, edgeSubset)
   }
 
+  // TODO(Question for Ozzie): Why aren't these passing oneLevel down? Seems like this shouldn't work...
   children(id, oneLevel=true) {
-    return this.childrenIds(id, oneLevel).map(e => this.nodes.find(m => m.id === e))
+    return this.childrenIds(id).map(e => this.nodes.find(m => m.id === e))
+  }
+
+  parents(id, oneLevel=true) {
+    return this.parentIds(id).map(e => this.nodes.find(m => m.id === e))
   }
 
   childrenIds(id, oneLevel=true) {
@@ -32,6 +37,16 @@ export default class BasicGraph {
       newEdges = this.edges.filter(e => _.some(descendants, d => d.id === e.input))
     }
     return descendants
+  }
+
+  // TODO(Question for Ozzie): Why didn't I have to fix this too? Is this function ever being called? Is this actually
+  // used?
+  parentIds(id, oneLevel=true) {
+    const oneLevelParents = this.edges.filter(e => e.output === id).map(e => e.input)
+    return oneLevel ?
+      oneLevelParents
+      :
+      _.uniq(_.flattenDeep([oneLevelParents, oneLevelParents.map(e => this.parentsIds(e, false))]))
   }
 }
 

--- a/src/lib/basic_graph/basic-graph.js
+++ b/src/lib/basic_graph/basic-graph.js
@@ -13,6 +13,7 @@ export default class BasicGraph {
     return new BasicGraph(itemSubset, edgeSubset)
   }
 
+  // TODO(Question for Ozzie): Why aren't these passing oneLevel down? Seems like this shouldn't work...
   children(id, oneLevel=true) {
     return this.childrenIds(id).map(e => this.nodes.find(m => m.id === e))
   }
@@ -22,13 +23,24 @@ export default class BasicGraph {
   }
 
   childrenIds(id, oneLevel=true) {
-    const oneLevelChildren = this.edges.filter(e => e.input === id).map(e => e.output)
-    return oneLevel ?
-      oneLevelChildren
-      :
-      _.uniq(_.flattenDeep([oneLevelChildren, oneLevelChildren.map(e => this.childrenIds(e, false))]))
+    let seen = this.edges.filter(e => e.input === id)
+    let descendants = seen.map(e => e.output)
+    if (oneLevel) {return descendants}
+
+    let newEdges = this.edges.filter(e => _.some(descendants, d => d.id === e.input))
+    while (newEdges.length > 0) {
+      if (_.some(newEdges, e => _.some(seen, s => s === e))) {
+        break
+      }
+      descendants = _.uniq(descendants.concat(newEdges.map(e => e.output)))
+      seen = seen.concat(newEdges)
+      newEdges = this.edges.filter(e => _.some(descendants, d => d.id === e.input))
+    }
+    return descendants
   }
 
+  // TODO(Question for Ozzie): Why didn't I have to fix this too? Is this function ever being called? Is this actually
+  // used?
   parentIds(id, oneLevel=true) {
     const oneLevelParents = this.edges.filter(e => e.output === id).map(e => e.input)
     return oneLevel ?

--- a/src/lib/basic_graph/basic-graph.js
+++ b/src/lib/basic_graph/basic-graph.js
@@ -13,13 +13,8 @@ export default class BasicGraph {
     return new BasicGraph(itemSubset, edgeSubset)
   }
 
-  // TODO(Question for Ozzie): Why aren't these passing oneLevel down? Seems like this shouldn't work...
   children(id, oneLevel=true) {
-    return this.childrenIds(id).map(e => this.nodes.find(m => m.id === e))
-  }
-
-  parents(id, oneLevel=true) {
-    return this.parentIds(id).map(e => this.nodes.find(m => m.id === e))
+    return this.childrenIds(id, oneLevel).map(e => this.nodes.find(m => m.id === e))
   }
 
   childrenIds(id, oneLevel=true) {
@@ -37,16 +32,6 @@ export default class BasicGraph {
       newEdges = this.edges.filter(e => _.some(descendants, d => d.id === e.input))
     }
     return descendants
-  }
-
-  // TODO(Question for Ozzie): Why didn't I have to fix this too? Is this function ever being called? Is this actually
-  // used?
-  parentIds(id, oneLevel=true) {
-    const oneLevelParents = this.edges.filter(e => e.output === id).map(e => e.input)
-    return oneLevel ?
-      oneLevelParents
-      :
-      _.uniq(_.flattenDeep([oneLevelParents, oneLevelParents.map(e => this.parentsIds(e, false))]))
   }
 }
 

--- a/src/lib/basic_graph/basic-graph.js
+++ b/src/lib/basic_graph/basic-graph.js
@@ -18,8 +18,8 @@ export default class BasicGraph {
     return this.childrenIds(id).map(e => this.nodes.find(m => m.id === e))
   }
 
-  parents(id, oneLevel=true) {
-    return this.parentIds(id).map(e => this.nodes.find(m => m.id === e))
+  directParents(id) {
+    return this.directParentIds(id).map(e => this.nodes.find(m => m.id === e))
   }
 
   childrenIds(id, oneLevel=true) {
@@ -39,14 +39,8 @@ export default class BasicGraph {
     return descendants
   }
 
-  // TODO(Question for Ozzie): Why didn't I have to fix this too? Is this function ever being called? Is this actually
-  // used?
-  parentIds(id, oneLevel=true) {
-    const oneLevelParents = this.edges.filter(e => e.output === id).map(e => e.input)
-    return oneLevel ?
-      oneLevelParents
-      :
-      _.uniq(_.flattenDeep([oneLevelParents, oneLevelParents.map(e => this.parentsIds(e, false))]))
+  directParentIds(id) {
+    return this.edges.filter(e => e.output === id).map(e => e.input)
   }
 }
 

--- a/src/lib/basic_graph/basic-graph.js
+++ b/src/lib/basic_graph/basic-graph.js
@@ -27,6 +27,8 @@ export default class BasicGraph {
     let descendants = seen.map(e => e.output)
     if (oneLevel) {return descendants}
 
+    // Now we do a breadth first walk down the edges of the graph, checking to see if we've encountered an infinite loop
+    // at each stage.
     let newEdges = this.edges.filter(e => _.some(descendants, d => d.id === e.input))
     while (newEdges.length > 0) {
       if (_.some(newEdges, e => _.some(seen, s => s === e))) {

--- a/src/lib/basic_graph/basic-node.js
+++ b/src/lib/basic_graph/basic-node.js
@@ -8,8 +8,8 @@ export default class BasicNode {
     return this.graph.children(this.id, oneLevel)
   }
 
-  parents(oneLevel = true) {
-    return this.graph.parents(this.id, oneLevel)
+  directParents() {
+    return this.graph.directParents(this.id)
   }
 
   get maxDistanceFromRoot() {
@@ -25,8 +25,8 @@ export default class BasicNode {
     let ancestors = [this]
     while (ancestors.length > 0) {
       distanceFromRoot++
-      ancestors = _.uniq(_.flatten(ancestors.map(e => e.parents())))
-      ancestors = ancestors.filter( e => (e.id !== this.id) )
+      ancestors = _.uniq(_.flatten(ancestors.map(node => node.directParents())))
+      ancestors = ancestors.filter(node => (node.id !== this.id) )
     }
     return distanceFromRoot
   }

--- a/src/lib/basic_graph/basic-node.js
+++ b/src/lib/basic_graph/basic-node.js
@@ -8,6 +8,10 @@ export default class BasicNode {
     return this.graph.children(this.id, oneLevel)
   }
 
+  parents(oneLevel = true) {
+    return this.graph.parents(this.id, oneLevel)
+  }
+
   get maxDistanceFromRoot() {
     if (_.isUndefined(this._maxDistanceFromRoot)) {
       this._maxDistanceFromRoot = this._calculateMaxDistanceFromRoot()

--- a/src/lib/basic_graph/basic-node.js
+++ b/src/lib/basic_graph/basic-node.js
@@ -19,16 +19,6 @@ export default class BasicNode {
     return this._maxDistanceFromRoot
   }
 
-  // TODO(Question for Ozzie): Should this be 'maxParentDistanceFromRoot'?
-  _calculateMaxDistanceFromRootOld(): integer {
-    if (_.isEmpty(this.parents())) {
-      return 0
-    } else {
-      const maxChildDistanceFromRoot = Math.max(...this.parents().map(c => c.maxDistanceFromRoot))
-      return (maxChildDistanceFromRoot + 1)
-    }
-  }
-
   _calculateMaxDistanceFromRoot(): integer {
     // We initialize to -1 as you alwasy get one increment for free in the loop below.
     let distanceFromRoot = -1

--- a/src/lib/basic_graph/basic-node.js
+++ b/src/lib/basic_graph/basic-node.js
@@ -8,10 +8,6 @@ export default class BasicNode {
     return this.graph.children(this.id, oneLevel)
   }
 
-  parents(oneLevel = true) {
-    return this.graph.parents(this.id, oneLevel)
-  }
-
   get maxDistanceFromRoot() {
     if (_.isUndefined(this._maxDistanceFromRoot)) {
       this._maxDistanceFromRoot = this._calculateMaxDistanceFromRoot()

--- a/src/lib/basic_graph/basic-node.js
+++ b/src/lib/basic_graph/basic-node.js
@@ -19,12 +19,25 @@ export default class BasicNode {
     return this._maxDistanceFromRoot
   }
 
-  _calculateMaxDistanceFromRoot(): integer {
+  // TODO(Question for Ozzie): Should this be 'maxParentDistanceFromRoot'?
+  _calculateMaxDistanceFromRootOld(): integer {
     if (_.isEmpty(this.parents())) {
       return 0
     } else {
       const maxChildDistanceFromRoot = Math.max(...this.parents().map(c => c.maxDistanceFromRoot))
       return (maxChildDistanceFromRoot + 1)
     }
+  }
+
+  _calculateMaxDistanceFromRoot(): integer {
+    // We initialize to -1 as you alwasy get one increment for free in the loop below.
+    let distanceFromRoot = -1
+    let ancestors = [this]
+    while (ancestors.length > 0) {
+      distanceFromRoot++
+      ancestors = _.uniq(_.flatten(ancestors.map(e => e.parents())))
+      ancestors = ancestors.filter( e => (e.id !== this.id) )
+    }
+    return distanceFromRoot
   }
 }


### PR DESCRIPTION
This stops the breakage from being as catastrophic, though adds no notice to the user that an infinite loop is the problem (and doesn't communicate that to anywhere else in the program).