### PR TITLE
Transform the ratio taking to ensure that small numbers don't disproportionately affect the results.

### DIFF
--- a/src/components/lib/histogram.js
+++ b/src/components/lib/histogram.js
@@ -20,9 +20,10 @@ function avg(arr) {
   return arr.length > 0 ? arr.reduce((a,b)=>a+b)/arr.length : 1
 }
 
-// Computes min(|a|,|b|)/max(|a|,|b|).
-function fractionLessThanOne(a,b) {
-  return Math.min(Math.abs(a),Math.abs(b))/Math.max(Math.abs(a),Math.abs(b))
+// Computes (min(|a|,|b|)+100)/(max(|a|,|b|)+100). We add 100 to both numerator and denominator to ensure that small
+// numbers don't disproprortionately affect results.
+function shiftedRatio(a,b) {
+  return (Math.min(Math.abs(a),Math.abs(b))+100)/(Math.max(Math.abs(a),Math.abs(b))+100)
 }
 
 // filterLowDensityPoints removes points that occur in only low density regions of the histogram, to ensure that only
@@ -47,7 +48,7 @@ function filterLowDensityPoints(inputData, cutOffRatio) {
   let right = outputData.slice(bucketSize,2*bucketSize)
   // As long as the ratio of the magnitude of their averages is less than the cutOffRatio, we keep discarding the left
   // endpoint and iterating along the array.
-  while (fractionLessThanOne(avg(left),avg(right)) < cutOffRatio) {
+  while (shiftedRatio(avg(left),avg(right)) < cutOffRatio) {
     outputData = outputData.slice(bucketSize)
     left = outputData.slice(0,bucketSize)
     right = outputData.slice(bucketSize,2*bucketSize)
@@ -56,7 +57,7 @@ function filterLowDensityPoints(inputData, cutOffRatio) {
   // Filter Right, analogous to how we filter the left, but in reverse.
   left = outputData.slice(-2*bucketSize,-bucketSize)
   right = outputData.slice(-bucketSize)
-  while (fractionLessThanOne(avg(left),avg(right)) < cutOffRatio) {
+  while (shiftedRatio(avg(left),avg(right)) < cutOffRatio) {
     outputData = outputData.slice(0,-bucketSize)
     left = outputData.slice(-2*bucketSize,-bucketSize)
     right = outputData.slice(-bucketSize)


### PR DESCRIPTION
Some results.
Before (`[1,10]`):
![current-1-10](https://cloud.githubusercontent.com/assets/470751/14651173/a70863d6-0623-11e6-904d-375be163af66.png)
After:
![p100-1-10](https://cloud.githubusercontent.com/assets/470751/14651180/aa9ae0e6-0623-11e6-9741-6b93fa2284d6.png)
Before (`[1,1000]`):
![current-1-1000](https://cloud.githubusercontent.com/assets/470751/14651188/afcc8e3e-0623-11e6-80c9-c9d11fbd33f2.png)
After:
![p100-1-1000](https://cloud.githubusercontent.com/assets/470751/14651192/b4051e26-0623-11e6-93ab-ed55448def00.png)
Before (`=normal(50,22)`):
![current-normal](https://cloud.githubusercontent.com/assets/470751/14651196/b9134442-0623-11e6-8a47-495af03e322b.png)
After:
![p100 normal](https://cloud.githubusercontent.com/assets/470751/14651199/bc965ce4-0623-11e6-82a2-020b64d6f546.png)