### PR TITLE
Do not clone graph before debounce

### DIFF
--- a/src/lib/engine/graph.js
+++ b/src/lib/engine/graph.js
@@ -46,19 +46,20 @@ export function dependencyList(graph, spaceId) {
 // This could be optimized for filtering the graph by the space subset
 export function dependencyTree(oGraph, graphFilters) {
   const {spaceId, metricId, onlyHead, notHead} = graphFilters
-
-  let graph = oGraph
-  if (spaceId) { graph = _space.subset(oGraph, spaceId) }
-
-  let bGraph = basicGraph(graph)
-  if (metricId) { bGraph = bGraph.subsetFrom(metricId) }
-
-  const nodes =  bGraph.nodes.map(n => [n.id, n.maxDistanceFromRoot])
   if (onlyHead) {
-    return nodes.filter(e => (e[0] === metricId))
-  } else if (notHead){
-    return nodes.filter(e => (e[0] !== metricId))
+    return [[metricId, 0]]
   } else {
-    return nodes
+    let graph = oGraph
+    if (spaceId) { graph = _space.subset(oGraph, spaceId) }
+
+    let bGraph = basicGraph(graph)
+    if (metricId) { bGraph = bGraph.subsetFrom(metricId) }
+
+    const nodes =  bGraph.nodes.map(n => [n.id, n.maxDistanceFromRoot])
+    if (notHead){
+      return nodes.filter(e => (e[0] !== metricId))
+    } else {
+      return nodes
+    }
   }
 }

--- a/src/lib/propagation/graph-propagation.js
+++ b/src/lib/propagation/graph-propagation.js
@@ -73,6 +73,7 @@ export class GraphPropagation {
   }
 
   _orderedMetricIds(graphFilters: object): Array<Object> {
+    if (graphFilters.onlyHead) { return [graphFilters.metricId]}
     this.dependencies = e.graph.dependencyTree(this._graph(), graphFilters)
     const inOrder = _.sortBy(this.dependencies, function(n){return n[1]}).map(e => e[0])
     return inOrder


### PR DESCRIPTION
The ``space.subset`` function was dramatically slowing things down, and wasn't needed when the graphFilter ``onlyHead`` was passed in.