### PR TITLE
New Range Syntax for Metric Card

### DIFF
--- a/src/components/distributions/summary/index.js
+++ b/src/components/distributions/summary/index.js
@@ -47,7 +47,7 @@ class DistributionSummarySmall extends Component{
         <div className='mean'>
         <PrecisionNumber value={parseFloat(mean)} precision={precision}/>
         </div>
-        {!!low && !!high && high*low !== 0 &&
+        {!!low && !!high && (low !== high) &&
           <UncertaintyRange low={low} high={high} />
         }
       </div>

--- a/src/components/distributions/summary/index.js
+++ b/src/components/distributions/summary/index.js
@@ -21,6 +21,21 @@ const PrecisionNumber = ({value, precision}) => {
   )
 }
 
+const AsymmetricUncertainty = ({lowDelta, highDelta}) => (
+  <div className='stdev asymmetric'>
+    <div className='pm'>
+      <div className='symbols'>
+        <div className='plus'>+</div>
+        <div className='minus'>-</div>
+      </div>
+      <div className='numbers'>
+        <div className='number'><PrecisionNumber value={highDelta}/></div>
+        <div className='number'><PrecisionNumber value={lowDelta}/></div>
+      </div>
+    </div>
+  </div>
+)
+
 const Uncertainty = ({range}) => (
   <span className='stdev'> {'±'} <PrecisionNumber value={range}/> </span>
 )
@@ -31,22 +46,39 @@ class DistributionSummarySmall extends Component{
     stats: PropTypes.object,
   }
   render () {
-    const {length, mean, stdev, percentiles} = this.props.stats
+    const {length, mean, stdev, adjustedPercentiles} = this.props.stats
 
     let range = null
-    if (_.isObject(percentiles)) {
-      const [lowRange, highRange] = [(mean - percentiles[5]), (percentiles[95] - mean)]
-      range = (highRange + lowRange) / 2
+    let low = null
+    let high = null
+    let lowDelta = null
+    let highDelta = null
+    if (_.isObject(adjustedPercentiles)) {
+      [low, high] = [adjustedPercentiles[5], adjustedPercentiles[95]]
+      range = mean - ((high + low) / 2)
+      lowDelta = mean - low
+      highDelta = high - mean
     }
 
     const precision = length === 1 ? 6 : 2
 
+    const symmetric = false
+    const ninetypercentCI = false
+    const asymmetric = true
+
     return (
       <div className="DistributionSummary">
+        <div className='mean'>
         <PrecisionNumber value={parseFloat(mean)} precision={precision}/>
-          {!!range && range !== 0 &&
-          <Uncertainty range={range} />
-          }
+        </div>
+        {symmetric &&
+          !!range && range !== 0 &&
+            <Uncertainty range={range} />
+        }
+        {asymmetric &&
+          !!lowDelta && !!highDelta && highDelta*lowDelta !== 0 &&
+            <AsymmetricUncertainty lowDelta={lowDelta} highDelta={highDelta} />
+        }
       </div>
     )
   }

--- a/src/components/distributions/summary/index.js
+++ b/src/components/distributions/summary/index.js
@@ -33,13 +33,12 @@ class DistributionSummarySmall extends Component{
     stats: PropTypes.object,
   }
   render () {
-    const {length, mean, stdev, adjustedPercentiles} = this.props.stats
+    const {length, mean, stdev, adjustedConfidenceInterval} = this.props.stats
 
-    let range = null
-    let low = null
-    let high = null
-    if (_.isObject(adjustedPercentiles)) {
-      [low, high] = [adjustedPercentiles[5], adjustedPercentiles[95]]
+    let low
+    let high
+    if (_.isObject(adjustedConfidenceInterval)) {
+      [low, high] = adjustedConfidenceInterval
     }
 
     const precision = length === 1 ? 6 : 2

--- a/src/components/distributions/summary/index.js
+++ b/src/components/distributions/summary/index.js
@@ -21,23 +21,10 @@ const PrecisionNumber = ({value, precision}) => {
   )
 }
 
-const AsymmetricUncertainty = ({lowDelta, highDelta}) => (
-  <div className='stdev asymmetric'>
-    <div className='pm'>
-      <div className='symbols'>
-        <div className='plus'>+</div>
-        <div className='minus'>-</div>
-      </div>
-      <div className='numbers'>
-        <div className='number'><PrecisionNumber value={highDelta}/></div>
-        <div className='number'><PrecisionNumber value={lowDelta}/></div>
-      </div>
-    </div>
+const UncertaintyRange = ({low, high}) => (
+  <div className='UncertaintyRange'>
+    <PrecisionNumber value={low}/> to <PrecisionNumber value={high}/>
   </div>
-)
-
-const Uncertainty = ({range}) => (
-  <span className='stdev'> {'±'} <PrecisionNumber value={range}/> </span>
 )
 
 @ShowIf
@@ -51,33 +38,18 @@ class DistributionSummarySmall extends Component{
     let range = null
     let low = null
     let high = null
-    let lowDelta = null
-    let highDelta = null
     if (_.isObject(adjustedPercentiles)) {
       [low, high] = [adjustedPercentiles[5], adjustedPercentiles[95]]
-      range = mean - ((high + low) / 2)
-      lowDelta = mean - low
-      highDelta = high - mean
     }
 
     const precision = length === 1 ? 6 : 2
-
-    const symmetric = false
-    const ninetypercentCI = false
-    const asymmetric = true
-
     return (
       <div className="DistributionSummary">
         <div className='mean'>
         <PrecisionNumber value={parseFloat(mean)} precision={precision}/>
         </div>
-        {symmetric &&
-          !!range && range !== 0 &&
-            <Uncertainty range={range} />
-        }
-        {asymmetric &&
-          !!lowDelta && !!highDelta && highDelta*lowDelta !== 0 &&
-            <AsymmetricUncertainty lowDelta={lowDelta} highDelta={highDelta} />
+        {!!low && !!high && high*low !== 0 &&
+          <UncertaintyRange low={low} high={high} />
         }
       </div>
     )

--- a/src/components/distributions/summary/style.css
+++ b/src/components/distributions/summary/style.css
@@ -4,47 +4,17 @@
   font-size: 1.6em;
 }
 
-.DistributionSummary .symbols{
-  float: left;
-  color: #888;
-  font-size: 0.8em;
-  margin-top: -1px;
-}
-
-.DistributionSummary .symbols .plus{
-}
-
-.DistributionSummary .symbols .minus{
-  font-size: 1.6em;
-}
-
-.DistributionSummary .numbers{
-  float: left;
-  margin-left: 2px;
-}
-
 .DistributionSummary .mean {
   float: left;
+  width: 100%;
 }
 
-.DistributionSummary .stdev {
-  margin-left: 0.25em;
-  font-size: 0.75em;
-  color: #666;
-}
-
-.DistributionSummary .stdev.asymmetric {
-  margin-left: 0.4em;
-  font-size: 0.53em;
-  line-height: 1em;
+.DistributionSummary .UncertaintyRange {
+  font-size: 0.58em;
   color: #555;
   float: left;
-  margin-top: 2px;
-  font-weight: 400;
-}
-
-.DistributionSummary .stdev.asymmetric .pm {
-  margin-top: -0.4em;
+  margin-top: 13px;
+  margin-left: 0;
 }
 
 .DistributionSummary .PrecisionNumber {

--- a/src/components/distributions/summary/style.css
+++ b/src/components/distributions/summary/style.css
@@ -13,7 +13,7 @@
   font-size: 0.58em;
   color: #555;
   float: left;
-  margin-top: 13px;
+  margin-top: 5px;
   margin-left: 0;
 }
 

--- a/src/components/distributions/summary/style.css
+++ b/src/components/distributions/summary/style.css
@@ -4,10 +4,27 @@
   font-size: 1.6em;
 }
 
+.DistributionSummary .symbols{
+  float: left;
+  color: #888;
+  font-size: 0.8em;
+  margin-top: -1px;
+}
+
+.DistributionSummary .symbols .plus{
+}
+
+.DistributionSummary .symbols .minus{
+  font-size: 1.6em;
+}
+
+.DistributionSummary .numbers{
+  float: left;
+  margin-left: 2px;
+}
+
 .DistributionSummary .mean {
-  font-weight: 500;
-  font-size: 1.5em;
-  color: $black-1;
+  float: left;
 }
 
 .DistributionSummary .stdev {
@@ -16,3 +33,20 @@
   color: #666;
 }
 
+.DistributionSummary .stdev.asymmetric {
+  margin-left: 0.4em;
+  font-size: 0.53em;
+  line-height: 1em;
+  color: #555;
+  float: left;
+  margin-top: 2px;
+  font-weight: 400;
+}
+
+.DistributionSummary .stdev.asymmetric .pm {
+  margin-top: -0.4em;
+}
+
+.DistributionSummary .PrecisionNumber {
+  float: left;
+}

--- a/src/components/metrics/card/style.css
+++ b/src/components/metrics/card/style.css
@@ -50,7 +50,7 @@
 .metricCard > .section {
   position: relative;
   flex: 1;
-  padding: 0.35em;
+  padding: 0.3em 0.3em 0.2em 0.3em;
 }
 
 .metricCard .react-d3-histogram {

--- a/src/modules/simulations/reducer.js
+++ b/src/modules/simulations/reducer.js
@@ -6,6 +6,7 @@ function hasNoStdev(values) {
   return (_.uniq(_.slice(values, 0, 5)).length === 1)
 }
 
+window.stats = Stats
 function sStats(simulation){
   if (_.has(simulation, 'sample.values') && (simulation.sample.values.length > 0)) {
     let values = simulation.sample.values;
@@ -14,11 +15,19 @@ function sStats(simulation){
     //stats had bug where it would treat very tiny values (< 10^-10) as sometimes having a tiny stdev (<10^-30)
     const percentiles = {5: s1.percentile(5), 50: s1.percentile(50), 95: s1.percentile(95)}
     let stdev = hasNoStdev(values) ? 0 : s1.stddev()
+    const mean = s1.amean()
+    const stats = Stats
+    const lowValue = (new Stats().push(values.filter(e => e < mean))).percentile(10)
+    const highValue = (new Stats().push(values.filter(e => e > mean))).percentile(90)
     return {
-      mean:  s1.amean(),
+      mean,
       stdev:  stdev,
       length:  values.length,
-      percentiles
+      percentiles,
+      adjustedPercentiles: {
+        5: lowValue,
+        95: highValue
+      }
     };
   }
 }

--- a/src/modules/simulations/reducer.js
+++ b/src/modules/simulations/reducer.js
@@ -6,7 +6,6 @@ function hasNoStdev(values) {
   return (_.uniq(_.slice(values, 0, 5)).length === 1)
 }
 
-window.stats = Stats
 function sStats(simulation){
   if (_.has(simulation, 'sample.values') && (simulation.sample.values.length > 0)) {
     let values = simulation.sample.values;
@@ -16,18 +15,16 @@ function sStats(simulation){
     const percentiles = {5: s1.percentile(5), 50: s1.percentile(50), 95: s1.percentile(95)}
     let stdev = hasNoStdev(values) ? 0 : s1.stddev()
     const mean = s1.amean()
-    const stats = Stats
-    const lowValue = (new Stats().push(values.filter(e => e < mean))).percentile(10)
-    const highValue = (new Stats().push(values.filter(e => e > mean))).percentile(90)
+
+    const adjustedLow = (new Stats().push(values.filter(e => e < mean))).percentile(10)
+    const adjustedHigh = (new Stats().push(values.filter(e => e > mean))).percentile(90)
+
     return {
       mean,
       stdev:  stdev,
       length:  values.length,
       percentiles,
-      adjustedPercentiles: {
-        5: lowValue,
-        95: highValue
-      }
+      adjustedConfidenceInterval: [adjustedLow, adjustedHigh]
     };
   }
 }


### PR DESCRIPTION
## Before
![image](https://cloud.githubusercontent.com/assets/377065/14830954/3b4a6c22-0ba8-11e6-8e92-85b9a63a8946.png)

## After
![image](https://cloud.githubusercontent.com/assets/377065/14831075/df8d95ac-0ba8-11e6-8d57-dda339f631f5.png)

Not that this doesn't show exactly the 5th to 95th percentiles.  Instead it shows the 10th percentiles for all numbers lower than the mean, and the 90th percentile for all numbers higher than the mean.  This means that it is still a 90% confidence interval, but that now it can not be outside the bounds of the mean.  We've found that when the range is outside the mean some people became very confused, plus the fact that in these cases, the extreme ends would be very significant.
