### PR TITLE
Only the Stats metric card section should be draggable

### DIFF
--- a/src/components/lib/FlowGrid/filled-cell.js
+++ b/src/components/lib/FlowGrid/filled-cell.js
@@ -38,7 +38,8 @@ export default class ItemCell extends Component {
         {
           hovered: this.props.hover,
           isSelected: this.props.isSelected,
-          gridKeyPress: this.props.gridKeyPress
+          gridKeyPress: this.props.gridKeyPress,
+          connectDragSource: this.props.connectDragSource
         }
     )
   }
@@ -46,7 +47,7 @@ export default class ItemCell extends Component {
   render = () => {
     let classes = 'FlowGridFilledCell'
     classes += this.props.isDragging ? ' isDragging' : ''
-    return this.props.connectDragSource(
+    return this.props.connectDragPreview(
       <div className={classes}>
         {!this.props.isDragging && this.item()}
       </div>

--- a/src/components/metrics/card/MetricCardViewSection/index.js
+++ b/src/components/metrics/card/MetricCardViewSection/index.js
@@ -69,7 +69,7 @@ export default class MetricCardViewSection extends Component {
 
     return(
       <div className={`MetricCardViewSection ${metricCardView} ${(hasErrors & !isSelected) ? 'hasErrors' : ''}`}
-          onMouseDown={onClick}
+          onMouseUp={onClick}
       >
         {(metricCardView !== 'basic') && showSimulation &&
           <Histogram height={(metricCardView === 'scientific') ? 110 : 30}
@@ -99,30 +99,34 @@ export default class MetricCardViewSection extends Component {
           </div>
         }
 
-        <div className='StatsSection'>
-          {showSimulation &&
-            <div className='StatsSectionBody'>
-              <DistributionSummary
-                  guesstimateForm={guesstimateForm}
-                  simulation={metric.simulation}
-              />
-            </div>
-          }
+        {this.props.connectDragSource(
+          <div className='StatsSection'>
+            {showSimulation &&
+              <div className='StatsSectionBody'>
+                <DistributionSummary
+                    guesstimateForm={guesstimateForm}
+                    simulation={metric.simulation}
+                />
+              </div>
+            }
+            {showSimulation && shouldShowStatistics &&
+              <div className='StatsSectionTable'>
+                <StatTable stats={metric.simulation.stats}/>
+              </div>
+            }
 
-          {hasErrors &&
-            <ErrorSection
-              errors={errors}
-              padTop={(!_.isEmpty(metric.name) && !isSelected)}
-              hide={isSelected}
-            />
-          }
-        </div>
+            {hasErrors &&
+              <ErrorSection
+                errors={errors}
+                padTop={(!_.isEmpty(metric.name) && !isSelected)}
+                hide={isSelected}
+              />
+            }
+          </div>
+        )}
 
         {shouldShowJsonTree &&
           <div className='row'> <div className='col-xs-12'> <JSONTree data={this.props}/> </div> </div>
-        }
-        {shouldShowStatistics &&
-          <div className='row'> <div className='col-xs-12'> <StatTable stats={metric.simulation.stats}/> </div> </div>
         }
       </div>
     )

--- a/src/components/metrics/card/MetricCardViewSection/style.css
+++ b/src/components/metrics/card/MetricCardViewSection/style.css
@@ -53,15 +53,18 @@
 }
 
 .MetricCardViewSection > .StatsSection {
+  cursor: move;
   width: 100%;
   float: left;
   min-height: 10px;
   flex: 5;
   display: flex;
+  flex-direction: column;
 }
 
 .MetricCardViewSection > .StatsSection .StatsSectionBody {
   padding: 8px 6px 4px 7px;
+  flex: 5;
 }
 
 .MetricCardViewSection > .StatsSection .StatsSectionErrors {
@@ -86,3 +89,9 @@
   color: #444
 }
 
+.MetricCardViewSection .StatsSectionTable {
+  padding: 4px 7px;
+  background-color: rgba(255,255,255,0.3);
+  margin-top: 10px;
+  flex: 1;
+}

--- a/src/components/metrics/card/index.js
+++ b/src/components/metrics/card/index.js
@@ -196,6 +196,7 @@ class MetricCard extends Component {
               onClick={this._handleClick.bind(this)}
               ref='MetricCardViewSection'
               isTitle={this._isTitle()}
+              connectDragSource={this.props.connectDragSource}
           />
 
           {isSelected && !this.state.modalIsOpen &&

--- a/src/components/metrics/card/style.css
+++ b/src/components/metrics/card/style.css
@@ -16,7 +16,6 @@
   font-weight: 300;
   width: 100%;
   display:flex;
-  cursor: move;
   flex-direction: column;
   overflow: hidden;
 }

--- a/src/components/simulations/stat_table/style.css
+++ b/src/components/simulations/stat_table/style.css
@@ -1,16 +1,14 @@
 @import './styles/variables.css';
 
 table.MetricStatTable {
-  margin-top: 10px;
   font-weight: 500;
   font-size: 11px;
   color: #666;
-  width: 160px;
-  background-color: rgba(255,255,255,0.3);
-  margin-left: 6px;
+  width: 100%;
 }
 
 table.MetricStatTable td {
   text-align: left;
   padding: 0;
+  line-height: 1.5em;
 }


### PR DESCRIPTION
Previously the entire metric card was draggable.  This made editing with the text inputs difficult, especially with non-chrome browsers.