### PR TITLE
Don't resample data and show data histograms for even small data sets.

### DIFF
--- a/src/components/simulations/histogram/index.js
+++ b/src/components/simulations/histogram/index.js
@@ -44,7 +44,7 @@ class SimulationHistogram extends Component{
 
   render() {
     const values = this.values()
-    const hasValues =  (values && values.length >= 100)
+    const hasValues =  (values && values.length > 1)
     if (hasValues){
       return (this.histogram())
     } else {

--- a/src/lib/guesstimator/samplers/Data.js
+++ b/src/lib/guesstimator/samplers/Data.js
@@ -1,8 +1,6 @@
 export var Sampler = {
   sample(formatted, n) {
-    const {data} = formatted
-    const values = _.range(n).map(e => _.sample(data))
-    return Promise.resolve({values})
+    return Promise.resolve({values: formatted.data})
   }
 }
 

--- a/src/modules/simulations/reducer.js
+++ b/src/modules/simulations/reducer.js
@@ -6,7 +6,7 @@ function sStats(simulation){
   if (!_.has(simulation, 'sample.values') || (simulation.sample.values.length === 0)) {
     return
   }
-  const samples = sortDescending(simulation.sample.values)
+  const samples = sortDescending(Object.assign([], simulation.sample.values))
   const length = samples.length
   const mean = sampleMean(samples)
   const meanIndex = cutoff(samples, length, mean)


### PR DESCRIPTION
The two datasets below are negated versions of each other, so their sum should be 0 in every sample.
![no-resample-inputs](https://cloud.githubusercontent.com/assets/470751/15126233/e57b32ca-15e5-11e6-91f7-ae00a9a0bd41.png)