### PR TITLE
Proper data resampling.

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "_build": "BUILD_DEV=0 API_ENV=production webpack",
-    "_stage": "surge -p public -d test.getguesstimate.com",
+    "_stage": "surge -p public -d stage.getguesstimate.com",
     "start": "BUILD_DEV=0 NODE_ENV=development API_ENV=development webpack-dev-server",
     "start-production": "BUILD_DEV=0 NODE_ENV=development API_ENV=production webpack-dev-server",
     "stage!": "BUILD_DEV=0 npm run _build && npm run _stage",

--- a/src/lib/guesstimator/samplers/Simulator.js
+++ b/src/lib/guesstimator/samplers/Simulator.js
@@ -52,13 +52,7 @@ function neededSamples(text, inputs, n){
   }
 
   const numInputs = Object.keys(inputs).map(key => inputs[key].length)
-  const lcm = numInputs.reduce((x,y) => LCM(x,y))
-  const product = numInputs.reduce((x,y) => x*y)
-  if (product < n) {
-    return product
-  } else {
-    return Math.min(n, lcm)
-  }
+  return Math.min(n, numInputs.reduce((x,y) => LCM(x,y)))
 }
 
 function modularSlice(array, from, to) {

--- a/src/lib/guesstimator/samplers/Simulator.js
+++ b/src/lib/guesstimator/samplers/Simulator.js
@@ -52,6 +52,12 @@ function neededSamples(text, inputs, n){
   }
 
   const numInputs = Object.keys(inputs).map(key => inputs[key].length)
+  if (_.some(numInputs, i => i === n)) {
+    // No need to compute any further if any of the inputs are maximally sampled. This is a common case so is worth an
+    // edge case short circuit here, to avoid gcd/lcm calculation.
+    return n
+  }
+
   return Math.min(n, numInputs.reduce((x,y) => LCM(x,y)))
 }
 

--- a/src/lib/guesstimator/samplers/Simulator.js
+++ b/src/lib/guesstimator/samplers/Simulator.js
@@ -19,7 +19,8 @@ export function simulate(expr, inputs, maxSamples) {
   const numSamples = Math.floor(overallNumSamples/window.workers.length)
   const remainingSamples = numSamples + overallNumSamples % window.workers.length
 
-  const promises = [..._.map(
+  const promises = [
+    ..._.map(
       window.workers.slice(0,-1),
       (worker, index) => simulateOnWorker(worker, buildData(expr, index*numSamples, numSamples, inputs))
     ),

--- a/src/lib/guesstimator/samplers/Simulator.js
+++ b/src/lib/guesstimator/samplers/Simulator.js
@@ -61,10 +61,14 @@ function neededSamples(text, inputs, n){
   return Math.min(n, numInputs.reduce((x,y) => LCM(x,y)))
 }
 
+function rotate(array, newStart) {
+  return [...array.slice(newStart), ...array.slice(0,newStart)]
+}
+
 function modularSlice(array, from, to) {
   const len = array.length
   if (len <= to - from) {
-    return array
+    return rotate(array, to % len)
   }
   const [newFrom, newTo] = [from % len, to % len]
   if (newTo > newFrom) {

--- a/src/lib/guesstimator/samplers/simulator-worker/simulator/evaluator.js
+++ b/src/lib/guesstimator/samplers/simulator-worker/simulator/evaluator.js
@@ -30,28 +30,16 @@ math.import(financeFunctions, {override: true})
 math.import(ImpureConstructs, {override: true, wrap: true})
 
 // All of jStat's functions are impure as they require sampling on pure inputs.
-const STOCHASTIC_FUNCTIONS = ['pickRandom', 'randomInt', 'random'].concat(Object.keys(Distributions)).concat(Object.keys(ImpureConstructs))
+export const STOCHASTIC_FUNCTIONS = ['pickRandom', 'randomInt', 'random'].concat(Object.keys(Distributions)).concat(Object.keys(ImpureConstructs))
 
-export function Evaluate(text, n, inputs) {
+export function Evaluate(text, sampleCount, inputs) {
   try {
     const compiled = math.compile(text)
-    const sampleCount = requiresManySamples(text, inputs) ? n : 1
     return evaluate(compiled, inputs, sampleCount)
   } catch (exception) {
     let error = exception.message[0].toLowerCase() + exception.message.slice(1)
     return {errors: [error]}
   }
-}
-
-const hasStochasticFunction = text => _.some(STOCHASTIC_FUNCTIONS, e => text.indexOf(e) !== -1)
-
-export const requiresManySamples = (text, inputs) => {
-  for (let key of Object.keys(inputs)) {
-    if (_.some(inputs[key], i => i !== inputs[key][0])) { // Could also just do length === 1?
-      return true
-    }
-  }
-  return hasStochasticFunction(text)
 }
 
 function sampleInputs(inputs, i) {


### PR DESCRIPTION
This PR makes us run the minimal number of in-order sample necessary to fully explore any intersections between dependent datasets, assuming relation via modularity. This probably doesn't make too much sense long term (relation via modularity) but in the context of that relation this preserves statistical properties and gives correct means while minimizing sample count. Some number theory functions are added to compute how many samples we need to run before we'll run out of intersections to explore.
*This is deployed to stage and should be manually tested before merging.*