### PR TITLE
When card is dragged, do not show background

### DIFF
--- a/src/components/lib/FlowGrid/FlowGrid.css
+++ b/src/components/lib/FlowGrid/FlowGrid.css
@@ -80,6 +80,10 @@
   padding: 3px;
 }
 
+.FlowGridFilledCell .passThrough {
+  display: flex;
+}
+
 .showEdges .FlowGridFilledCell {
   padding: 8px;
 }

--- a/src/components/lib/FlowGrid/filled-cell.js
+++ b/src/components/lib/FlowGrid/filled-cell.js
@@ -47,9 +47,15 @@ export default class ItemCell extends Component {
   render = () => {
     let classes = 'FlowGridFilledCell'
     classes += this.props.isDragging ? ' isDragging' : ''
-    return this.props.connectDragPreview(
+    return (
       <div className={classes}>
-        {!this.props.isDragging && this.item()}
+        {!this.props.isDragging &&
+          this.props.connectDragPreview(
+            <span className='passThrough'>
+              {this.item()}
+            </span>
+          )
+        }
       </div>
     )
   }


### PR DESCRIPTION
There's still a small bug for some background color on bottom on occasion, but it's way better than dragging the entire card. 

![gif](http://g.recordit.co/rfCG5FsBN2.gif)