### PR TITLE
Multi-metric removal and addition should happen in one action.

### DIFF
--- a/src/components/lib/FlowGrid/FlowGrid.jsx
+++ b/src/components/lib/FlowGrid/FlowGrid.jsx
@@ -35,7 +35,7 @@ export default class FlowGrid extends Component{
     onDeSelectAll: PropTypes.func.isRequired,
     onAddItem: PropTypes.func.isRequired,
     onMoveItem: PropTypes.func.isRequired,
-    onRemoveItem: PropTypes.func.isRequired,
+    onRemoveItems: PropTypes.func.isRequired,
     onCopy: PropTypes.func.isRequired,
     onPaste: PropTypes.func.isRequired,
 
@@ -97,8 +97,7 @@ export default class FlowGrid extends Component{
   }
 
   _handleRemoveSelectedItems() {
-    const selectedItems = this._selectedItems()
-    selectedItems.map(i => {this.props.onRemoveItem(i.key)})
+    this.props.onRemoveItems(this._selectedItems().map(i => i.key))
   }
 
   _handleKeyDown(e){

--- a/src/components/metrics/card/index.js
+++ b/src/components/metrics/card/index.js
@@ -4,7 +4,7 @@ import {connect} from 'react-redux'
 import ReactDOM from 'react-dom'
 import $ from 'jquery'
 
-import {removeMetric, changeMetric} from 'gModules/metrics/actions'
+import {removeMetrics, changeMetric} from 'gModules/metrics/actions'
 import {changeGuesstimate} from 'gModules/guesstimates/actions'
 import {changeGuesstimateForm} from 'gModules/guesstimate_form/actions'
 
@@ -136,7 +136,7 @@ class MetricCard extends Component {
   }
 
   handleRemoveMetric () {
-    this.props.dispatch(removeMetric(this._id()))
+    this.props.dispatch(removeMetrics([this._id()]))
   }
 
   _id(){

--- a/src/components/spaces/canvas/index.js
+++ b/src/components/spaces/canvas/index.js
@@ -8,7 +8,7 @@ import Metric from 'gComponents/metrics/card/index'
 
 import {denormalizedSpaceSelector} from '../denormalized-space-selector'
 
-import {addMetric, changeMetric, removeMetric} from 'gModules/metrics/actions'
+import {addMetric, changeMetric, removeMetrics} from 'gModules/metrics/actions'
 import {copy, paste} from 'gModules/copied/actions'
 import {changeSelect, deSelect} from 'gModules/selected_cell/actions'
 import {selectRegion, deSelectRegion} from 'gModules/selected_region/actions'
@@ -194,7 +194,7 @@ export default class Canvas extends Component{
           onDeSelectAll={this._handleDeSelectAll.bind(this)}
           onAddItem={this._handleAddMetric.bind(this)}
           onMoveItem={this._handleMoveMetric.bind(this)}
-          onRemoveItem={(id) => {this.props.dispatch(removeMetric(id))}}
+          onRemoveItems={(ids) => {this.props.dispatch(removeMetrics(ids))}}
           onCopy={this._handleCopy.bind(this)}
           onPaste={this._handlePaste.bind(this)}
           showGridLines={showGridLines}

--- a/src/modules/copied/actions.js
+++ b/src/modules/copied/actions.js
@@ -68,9 +68,12 @@ export function paste(spaceId){
     )
 
     const existingMetrics = spaceMetrics.filter(m => isWithinRegion(m.location, pasteRegion))
-    dispatch(metricActions.removeMetrics(existingMetrics.map(m => m.id)))
-
-    newMetrics.forEach((newMetric, i) => {dispatch({type: 'ADD_METRIC', item: newMetric, newGuesstimate: newGuesstimates[i]})})
+    if (existingMetrics.length > 0) {
+      dispatch(metricActions.removeMetrics(existingMetrics.map(m => m.id)))
+    }
+    if (newMetrics.length > 0) {
+      dispatch({type: 'ADD_METRICS', items: newMetrics, newGuesstimates: newGuesstimates})
+    }
 
     dispatch(runSimulations({spaceId, metricSubset: newMetrics}))
     dispatch(selectRegion(pasteRegion[0], pasteRegion[1]))

--- a/src/modules/copied/actions.js
+++ b/src/modules/copied/actions.js
@@ -68,7 +68,7 @@ export function paste(spaceId){
     )
 
     const existingMetrics = spaceMetrics.filter(m => isWithinRegion(m.location, pasteRegion))
-    existingMetrics.forEach(existingMetric => {dispatch(metricActions.removeMetric(existingMetric.id))})
+    dispatch(metricActions.removeMetrics(existingMetrics.map(m => m.id)))
 
     newMetrics.forEach((newMetric, i) => {dispatch({type: 'ADD_METRIC', item: newMetric, newGuesstimate: newGuesstimates[i]})})
 

--- a/src/modules/guesstimates/reducer.js
+++ b/src/modules/guesstimates/reducer.js
@@ -17,8 +17,8 @@ export default function guesstimates(state = [], action) {
       // Build a new guesstimate if not provided
       return uniq([...state, {metric: action.item.id, input: '', guesstimateType: 'NONE', description: ''}])
     }
-  case 'REMOVE_METRIC':
-    return state.filter(y => y.metric !== action.item.id)
+  case 'REMOVE_METRICS':
+    return state.filter(y => !_.some(action.item.ids, id => y.metric === id))
   case 'CHANGE_GUESSTIMATE':
     const i = state.findIndex(y => y.metric === action.values.metric);
     const newItem = engine.guesstimate.format(action.values)

--- a/src/modules/guesstimates/reducer.js
+++ b/src/modules/guesstimates/reducer.js
@@ -11,11 +11,13 @@ export default function guesstimates(state = [], action) {
     let newGuesstimates = _.flatten(action.records.map(e => _.get(e, 'graph.guesstimates'))).filter(e => e)
     return uniq([...state, ...newGuesstimates])
   case 'ADD_METRIC':
-    if (action.newGuesstimate) {
-      return uniq([...state, action.newGuesstimate])
+    return uniq([...state, {metric: action.item.id, input: '', guesstimateType: 'NONE', description: ''}])
+  case 'ADD_METRICS':
+    if (action.newGuesstimates) {
+      return uniq([...state, ...action.newGuesstimates])
     } else {
       // Build a new guesstimate if not provided
-      return uniq([...state, {metric: action.item.id, input: '', guesstimateType: 'NONE', description: ''}])
+      return uniq([...state, ...action.items.map(item => ({metric: item.id, input: '', guesstimateType: 'NONE', description: ''}))])
     }
   case 'REMOVE_METRICS':
     return state.filter(y => !_.some(action.item.ids, id => y.metric === id))

--- a/src/modules/metrics/actions.js
+++ b/src/modules/metrics/actions.js
@@ -21,11 +21,12 @@ export function addMetric(item) {
 }
 
 //spaceId must be done before the metric is removed here.
-export function removeMetric(id) {
+export function removeMetrics(ids) {
+  if (ids.length === 0) { return }
   return (dispatch, getState) => {
-    const spaceId = findSpaceId(getState, id)
+    const spaceId = findSpaceId(getState, ids[0])
 
-    dispatch({ type: 'REMOVE_METRIC', item: {id: id}});
+    dispatch({ type: 'REMOVE_METRICS', item: {ids}});
     registerGraphChange(dispatch, spaceId)
   }
 }

--- a/src/modules/metrics/reducer.js
+++ b/src/modules/metrics/reducer.js
@@ -15,6 +15,8 @@ export default function metrics(state = [], action) {
     return uniq([...state, ...newMetrics])
   case 'ADD_METRIC':
     return (uniq([...state, action.item]))
+  case 'ADD_METRICS':
+    return (uniq([...state, ...action.items]))
   case 'REMOVE_METRICS':
     return (state.filter(y => !_.some(action.item.ids, id => y.id === id)))
   case 'CHANGE_METRIC':

--- a/src/modules/metrics/reducer.js
+++ b/src/modules/metrics/reducer.js
@@ -15,8 +15,8 @@ export default function metrics(state = [], action) {
     return uniq([...state, ...newMetrics])
   case 'ADD_METRIC':
     return (uniq([...state, action.item]))
-  case 'REMOVE_METRIC':
-    return (state.filter(y => y.id !== action.item.id))
+  case 'REMOVE_METRICS':
+    return (state.filter(y => !_.some(action.item.ids, id => y.id === id)))
   case 'CHANGE_METRIC':
     const i = state.findIndex(y => y.id === action.item.id);
     const newItem = Object.assign(state[i], action.item);

--- a/src/modules/metrics/reducer.js
+++ b/src/modules/metrics/reducer.js
@@ -14,6 +14,7 @@ export default function metrics(state = [], action) {
     const newMetrics = (_.flatten(action.records.map(e => spaceToMetrics(e))).filter(e => e))
     return uniq([...state, ...newMetrics])
   case 'ADD_METRIC':
+    // TODO(matthew): Eliminate this (route everything through the multiple mode below).
     return (uniq([...state, action.item]))
   case 'ADD_METRICS':
     return (uniq([...state, ...action.items]))


### PR DESCRIPTION
This is important from a UI perspective because with undo, we want one ctrl-z press to bring back an entire swath of deleted metrics, not them all one at a time.