### PR TITLE
Metric names shouldn't be forms when not being editing.

### DIFF
--- a/src/components/metrics/card/name/index.js
+++ b/src/components/metrics/card/name/index.js
@@ -13,22 +13,34 @@ export default class MetricName extends Component {
     onChange: PropTypes.func.isRequired,
   }
 
-  state = {value: this.props.name}
+  state = {
+    value: this.props.name,
+    editing: false,
+  }
+
+  componentWillReceiveProps(nextProps) {
+    console.log("\n\n this.props.name", this.props.name)
+    console.log("this.state.value", this.state.value)
+    console.log("nextProps.name", nextProps.name)
+    if (this.props.name === this.state.value) {this.setState({value: nextProps.name})}
+  }
 
   shouldComponentUpdate(nextProps, nextState) {
     return ((nextProps.name !== this.props.name) ||
             (nextProps.inSelectedCell !== this.props.inSelectedCell) ||
-            (nextState.value !== this.state.value))
+            (nextState.value !== this.state.value) ||
+            (nextState.editing !== this.state.editing))
   }
 
   handleSubmit() {
     if (this._hasChanged()){
       this.props.onChange({name: this.state.value})
     }
+    this.setState({editing: false})
   }
 
   _hasChanged() {
-    return (this.state.value !== this.props.name)
+    return (this.state.value != this.props.name)
   }
 
   hasContent() {
@@ -55,15 +67,25 @@ export default class MetricName extends Component {
   render() {
     return (
       <div className='MetricName'>
-        <TextArea
+        {this.state.editing &&
+          <TextArea
             onBlur={this.handleSubmit.bind(this)}
             onChange={this.onChange.bind(this)}
             onKeyDown={this.handleKeyDown.bind(this)}
+            onMouseLeave={() => {if (!this._hasChanged()) {this.setState({editing: false})}}}
             placeholder={'name'}
             ref={'input'}
             tabIndex={2}
             value={this.state.value}
-        />
+          />
+        }
+        {!this.state.editing &&
+          <div
+            onMouseEnter={() => {this.setState({editing: true})}}
+          >
+            {this.state.value}
+          </div>
+        }
       </div>
     )
   }

--- a/src/components/metrics/card/name/index.js
+++ b/src/components/metrics/card/name/index.js
@@ -80,10 +80,10 @@ export default class MetricName extends Component {
           />
         }
         {!this.state.editing &&
-          <div
+          <div className={`static${!this.state.value ? ' default-value' : ''}`}
             onMouseEnter={() => {this.setState({editing: true})}}
           >
-            {this.state.value}
+            {this.state.value || 'name'}
           </div>
         }
       </div>

--- a/src/components/metrics/card/name/index.js
+++ b/src/components/metrics/card/name/index.js
@@ -19,9 +19,6 @@ export default class MetricName extends Component {
   }
 
   componentWillReceiveProps(nextProps) {
-    console.log("\n\n this.props.name", this.props.name)
-    console.log("this.state.value", this.state.value)
-    console.log("nextProps.name", nextProps.name)
     if (this.props.name === this.state.value) {this.setState({value: nextProps.name})}
   }
 

--- a/src/components/metrics/card/name/index.js
+++ b/src/components/metrics/card/name/index.js
@@ -76,7 +76,6 @@ export default class MetricName extends Component {
             onBlur={this.handleSubmit.bind(this)}
             onChange={this.onChange.bind(this)}
             onKeyDown={this.handleKeyDown.bind(this)}
-            onMouseLeave={() => {}}
             placeholder={'name'}
             ref={'input'}
             tabIndex={2}

--- a/src/components/metrics/card/name/index.js
+++ b/src/components/metrics/card/name/index.js
@@ -16,6 +16,7 @@ export default class MetricName extends Component {
   state = {
     value: this.props.name,
     editing: false,
+    persistEditing: false,
   }
 
   componentWillReceiveProps(nextProps) {
@@ -33,11 +34,17 @@ export default class MetricName extends Component {
     if (this._hasChanged()){
       this.props.onChange({name: this.state.value})
     }
-    this.setState({editing: false})
+    this.setState({editing: false, persistEditing: false})
   }
 
   _hasChanged() {
     return (this.state.value != this.props.name)
+  }
+
+  _handleMouseLeave() {
+    if (!(this.state.persistEditing || this._hasChanged())) {
+      this.setState({editing: false})
+    }
   }
 
   hasContent() {
@@ -69,7 +76,7 @@ export default class MetricName extends Component {
             onBlur={this.handleSubmit.bind(this)}
             onChange={this.onChange.bind(this)}
             onKeyDown={this.handleKeyDown.bind(this)}
-            onMouseLeave={() => {if (!this._hasChanged()) {this.setState({editing: false})}}}
+            onMouseLeave={() => {}}
             placeholder={'name'}
             ref={'input'}
             tabIndex={2}
@@ -79,6 +86,7 @@ export default class MetricName extends Component {
         {!this.state.editing &&
           <div className={`static${!this.state.value ? ' default-value' : ''}`}
             onMouseEnter={() => {this.setState({editing: true})}}
+            onClick={() => {this.setState({persistEditing: true})}}
           >
             {this.state.value || 'name'}
           </div>

--- a/src/components/metrics/card/name/style.css
+++ b/src/components/metrics/card/name/style.css
@@ -5,6 +5,22 @@
   width: 100%;
 }
 
+.MetricName .static{
+  @mixin hover-input;
+  padding: 2px;
+  color: $grey-2;
+  color: rgba(69, 98, 134, 0.83);
+  font-weight: 300;
+  width: 100%;
+  font-size: 0.99em;
+  float: left;
+  line-height: 1.2em;
+}
+
+.MetricName .static.default-value {
+  color: #A9A9A9;
+}
+
 .MetricName textarea{
   @mixin hover-input;
   padding: 2px;
@@ -17,19 +33,19 @@
   line-height: 1.2em;
 }
 
-.output .MetricName textarea {
+.output .MetricName .static {
    font-weight: 500;
 }
 
-.titleView .MetricName textarea{
+.titleView .MetricName .static{
   color: #3C4F67;
   font-weight: 600;
 }
 
-.MetricCardViewSection.display .MetricName textarea{
+.MetricCardViewSection.display .MetricName .static{
   overflow: hidden;
 }
 
-.metricCard.display .titleView .MetricName textarea{
+.metricCard.display .titleView .MetricName .static{
   color: #3C3F44;
 }

--- a/src/components/metrics/card/updated.js
+++ b/src/components/metrics/card/updated.js
@@ -2,6 +2,7 @@ export function hasMetricUpdated(oldProps, newProps) {
   return (
     _.get(oldProps, 'selectedMetric.id') !== _.get(newProps, 'selectedMetric.id') ||
     _.get(oldProps, 'selectedMetric.simulation.propagationId') !== _.get(newProps, 'selectedMetric.simulation.propagationId') ||
+    _.get(oldProps, 'metric.name') !== _.get(newProps, 'metric.name') ||
     oldProps.metric.isNew ||
     oldProps.inSelectedCell !== newProps.inSelectedCell ||
     oldProps.canvasState.metricCardView !== newProps.canvasState.metricCardView ||


### PR DESCRIPTION
In particular, this causes problems with undo (text areas steal focus). (deployed at stage.getguesstimate.com)