### PR TITLE
Make textareas still be styled correctly as a fallback.

### DIFF
--- a/src/components/metrics/card/name/style.css
+++ b/src/components/metrics/card/name/style.css
@@ -33,6 +33,23 @@
   line-height: 1.2em;
 }
 
+.output .MetricName textarea {
+   font-weight: 500;
+}
+
+.titleView .MetricName textarea {
+  color: #3C4F67;
+  font-weight: 600;
+}
+
+.MetricCardViewSection.display .MetricName textarea {
+  overflow: hidden;
+}
+
+.metricCard.display .titleView .MetricName textarea {
+  color: #3C3F44;
+}
+
 .output .MetricName .static {
    font-weight: 500;
 }


### PR DESCRIPTION
This is currently deployed (along with the other hotfix pull request). This is a safety measure to ensure even when our strategies fail, the styling stays correct.