### PR TITLE
Added background color for copied region

### DIFF
--- a/src/components/lib/FlowGrid/FlowGrid.css
+++ b/src/components/lib/FlowGrid/FlowGrid.css
@@ -154,8 +154,16 @@ svg.edge  path.basic-arrow.RED {
   fill: #B59893;
 }
 
-.SelectedRegion {
+.Region {
    position: absolute;
-   background: rgba(153, 186, 208, 0.87);
    border-radius: 3px;
+}
+
+.Region.selected {
+   background: rgba(153, 186, 208, 0.87);
+}
+
+.Region.copied {
+   border: 2px dashed rgba(7, 115, 167, 0.75);
+   background: rgba(153, 186, 208, 0.17);
 }

--- a/src/components/lib/FlowGrid/FlowGrid.css
+++ b/src/components/lib/FlowGrid/FlowGrid.css
@@ -154,16 +154,16 @@ svg.edge  path.basic-arrow.RED {
   fill: #B59893;
 }
 
-.Region {
+.FlowGrid .Region {
    position: absolute;
    border-radius: 3px;
 }
 
-.Region.selected {
+.FlowGrid .Region.selected {
    background: rgba(153, 186, 208, 0.87);
 }
 
-.Region.copied {
+.FlowGrid .Region.copied {
    border: 2px dashed rgba(7, 115, 167, 0.75);
    background: rgba(153, 186, 208, 0.17);
 }

--- a/src/components/lib/FlowGrid/FlowGrid.jsx
+++ b/src/components/lib/FlowGrid/FlowGrid.jsx
@@ -249,6 +249,7 @@ export default class FlowGrid extends Component{
                 rowCount={rowCount}
                 rowHeights={rowHeights}
                 selectedRegion={this.props.selectedRegion}
+                copiedRegion={this.props.copiedRegion}
               />
           </div>
         </div>

--- a/src/components/lib/FlowGrid/background-container.js
+++ b/src/components/lib/FlowGrid/background-container.js
@@ -8,12 +8,12 @@ import GridPoint from './gridPoints'
 import Dimensions from 'gComponents/utility/react-dimensions'
 
 
-const Region = ({rowHeights, columnWidth, selectedRegion}) => {
+const Region = ({rowHeights, columnWidth, selectedRegion, type}) => {
   if (!selectedRegion || selectedRegion.length !== 2) { return false }
   const gridPoint = new GridPoint({rowHeights, columnWidth, padding: 0})
   const region = gridPoint.region(selectedRegion)
   return (
-     <div className='SelectedRegion' style={region}/>
+     <div className={`Region ${type}`} style={region}/>
   )
 }
 
@@ -61,7 +61,18 @@ export default class BackgroundContainer extends Component {
             edges={edges}
             rowHeights={rowHeights}
         />
-        <Region rowHeights={rowHeights} columnWidth={columnWidth} selectedRegion={this.props.selectedRegion}/>
+        <Region
+          rowHeights={rowHeights}
+          columnWidth={columnWidth}
+          selectedRegion={this.props.selectedRegion}
+          type='selected'
+        />
+        <Region
+          rowHeights={rowHeights}
+          columnWidth={columnWidth}
+          selectedRegion={this.props.copiedRegion}
+          type='copied'
+        />
       </div>
     )
   }

--- a/src/components/spaces/canvas/index.js
+++ b/src/components/spaces/canvas/index.js
@@ -26,6 +26,7 @@ import {isLocation, isAtLocation} from 'lib/locationUtils.js'
 
 function mapStateToProps(state) {
   return {
+    copied: state.copied,
     canvasState: state.canvasState,
     selectedCell: state.selectedCell,
     selectedRegion: state.selectedRegion,
@@ -178,7 +179,7 @@ export default class Canvas extends Component{
   }
 
   render () {
-    const {selectedCell, selectedRegion} = this.props
+    const {selectedCell, selectedRegion, copied} = this.props
     const {metrics} = this.props.denormalizedSpace
     const {metricCardView} = this.props.canvasState
 
@@ -189,6 +190,8 @@ export default class Canvas extends Component{
     const selectedMetric = this._isAnalysisView() && this._selectedMetric()
     const overflow = this.props.screenshot ? 'hidden' : 'default'
 
+    const copiedRegion = (copied && (copied.pastedTimes < 1) && copied.region) || []
+
     return (
       <div className={className}>
         <FlowGrid
@@ -198,6 +201,7 @@ export default class Canvas extends Component{
           hasItemUpdated = {(oldItem, newItem) => hasMetricUpdated(oldItem.props, newItem.props)}
           edges={edges}
           selectedRegion={selectedRegion}
+          copiedRegion={copiedRegion}
           selectedCell={selectedCell}
           onUndo={this._handleUndo.bind(this)}
           onRedo={this._handleRedo.bind(this)}

--- a/src/modules/copied/actions.js
+++ b/src/modules/copied/actions.js
@@ -75,7 +75,7 @@ export function paste(spaceId){
       dispatch({type: 'ADD_METRICS', items: newMetrics, newGuesstimates: newGuesstimates})
     }
 
-    dispatch({type: "COPY_PASTE"})
+    dispatch({type: "PASTE"})
     dispatch(runSimulations({spaceId, metricSubset: newMetrics}))
     dispatch(selectRegion(pasteRegion[0], pasteRegion[1]))
     dispatch(registerGraphChange(spaceId))

--- a/src/modules/copied/actions.js
+++ b/src/modules/copied/actions.js
@@ -75,6 +75,7 @@ export function paste(spaceId){
       dispatch({type: 'ADD_METRICS', items: newMetrics, newGuesstimates: newGuesstimates})
     }
 
+    dispatch({type: "COPY_PASTE"})
     dispatch(runSimulations({spaceId, metricSubset: newMetrics}))
     dispatch(selectRegion(pasteRegion[0], pasteRegion[1]))
     dispatch(registerGraphChange(spaceId))

--- a/src/modules/copied/reducer.js
+++ b/src/modules/copied/reducer.js
@@ -1,7 +1,9 @@
 export const copiedR = (state = null, action) => {
   switch (action.type) {
     case 'COPY':
-      return action.copied
+      return {...action.copied, pastedTimes: 0}
+    case 'COPY_PASTE':
+      return {...state, pastedTimes: (state.pastedTimes + 1)}
     default:
       return state
   }

--- a/src/modules/copied/reducer.js
+++ b/src/modules/copied/reducer.js
@@ -2,7 +2,7 @@ export const copiedR = (state = null, action) => {
   switch (action.type) {
     case 'COPY':
       return {...action.copied, pastedTimes: 0}
-    case 'COPY_PASTE':
+    case 'PASTE':
       return {...state, pastedTimes: (state.pastedTimes + 1)}
     default:
       return state


### PR DESCRIPTION
The intended functionality is that the copied region of a canvas appears to have a dashed border around it.  After one paste, this goes away.  

One downside is that it's impossible to remove this selection without pasting, but I believe this is how similar tools do it.

![image](https://cloud.githubusercontent.com/assets/377065/15515628/020b9334-21a4-11e6-8eac-d9f3bb170517.png)
