### PR TITLE
Removing broken npm deploy rules.

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,8 +9,6 @@
     "start": "BUILD_DEV=1 NODE_ENV=development API_ENV=development SEGMENT_API_ENV=development webpack-dev-server",
     "start-production": "BUILD_DEV=1 NODE_ENV=development API_ENV=production SEGMENT_API_ENV=development webpack-dev-server",
     "stage": "npm run predeploy && npm run _stage",
-    "stage-netlify": "npm run predeploy && netlify deploy -s test-guesstimate public",
-    "deploy": "netlify deploy -s guesstimate public",
     "test": "karma start",
     "test-once": "karma start --single-run"
   },


### PR DESCRIPTION
These at best work by happenstance and at worst unintentionally deploy the code to the wrong site. I don't know why they don't work, but until it is figured out it seems best to remove them entirely.