### PR TITLE
Fix bug with returns in distribution editor.

### DIFF
--- a/src/components/distributions/editor/TextForm/TextInput.js
+++ b/src/components/distributions/editor/TextForm/TextInput.js
@@ -45,6 +45,7 @@ class TextInputEditor extends Component {
         <Editor
           onFocus={this.props.onFocus}
           editorState={editorState}
+          handleReturn={() => true}
           onBlur={this.props.onBlur}
           onChange={this._onChange.bind(this)}
           tabIndex={2}

--- a/src/components/metrics/card/name/index.js
+++ b/src/components/metrics/card/name/index.js
@@ -90,6 +90,7 @@ export default class MetricName extends Component {
   handleKeyDown(e) {
     e.stopPropagation()
     this.props.heightHasChanged()
+    // TODO(Ozzie): The code below currently doesn't work; kept here for potential future use.
     const ENTER = (e) => ((e.keyCode === 13) && !e.shiftKey)
     if (ENTER(e)){
       e.stopPropagation()


### PR DESCRIPTION
Draft JS Handler Documentation: 
"Cancelable Handlers (Optional) 
These prop functions are provided to allow custom event handling for a small set of useful events. By returning true from your handler, you indicate that the event is handled and the Draft core should do nothing more with it. By returning false, you defer to Draft to handle the event.
"