### PR TITLE
Css fixes to allow editing in Safari

### DIFF
--- a/src/components/metrics/card/style.css
+++ b/src/components/metrics/card/style.css
@@ -56,7 +56,7 @@
 .metricCard .section.editing {
   border-top: 1px solid #ddd;
   border-radius: 0 0 2px 2px;
-  flex: 0;
+  flex: 0 0 auto;
 }
 
 .metricCard--Container:focus {

--- a/src/components/spaces/canvas/style.css
+++ b/src/components/spaces/canvas/style.css
@@ -1,12 +1,3 @@
-.canvas-space {
-  -webkit-touch-callout: none;
-  -webkit-user-select: none;
-  -khtml-user-select: none;
-  -moz-user-select: none;
-  -ms-user-select: none;
-  user-select: none;
-}
-
 .canvas-space::selection {
   background-color: none
 }

--- a/src/components/spaces/cards/style.css
+++ b/src/components/spaces/cards/style.css
@@ -21,7 +21,7 @@
   padding: .5em;
   border-radius: 2px 2px 0 0;
   background-color: white;
-  flex: 0;
+  flex: 0 0 auto;
 }
 
 .SpaceCard .image {
@@ -29,7 +29,7 @@
   position: relative;
   background-color: #D8DADC;
   float: left;
-  flex: 0;
+  flex: 0 0 auto;
 }
 
 .SpaceCard .image img{


### PR DESCRIPTION
The remove of the user-select css does mean that highlighting the canvas will now work (it would be better if this wouldn't, as it is not intended).  However, this seems like a minor issue.