### PR TITLE
Auto select metric text forms

### DIFF
--- a/src/components/distributions/editor/TextForm/TextInput.js
+++ b/src/components/distributions/editor/TextForm/TextInput.js
@@ -33,6 +33,16 @@ class TextInputEditor extends Component {
     return this.setState({editorState})
   }
 
+  handleReturn(e) {
+    const shifted = e.shiftKey
+    if (shifted) {
+      return false
+    } else {
+      this.props.handleReturn()
+      return true
+    }
+  }
+
   render() {
     const {editorState} = this.state;
     return (
@@ -45,7 +55,7 @@ class TextInputEditor extends Component {
         <Editor
           onFocus={this.props.onFocus}
           editorState={editorState}
-          handleReturn={() => true}
+          handleReturn={this.handleReturn.bind(this)}
           onBlur={this.props.onBlur}
           onChange={this._onChange.bind(this)}
           tabIndex={2}
@@ -66,7 +76,7 @@ export default class TextInput extends Component{
 
   componentWillUnmount() { this._handleBlur() }
 
-  focus() { this.refs.input && this.refs.input.focus() }
+  focus() { this.refs.editor && this.refs.editor.focus() }
 
   _handleInputMetricClick(item){
     this.refs.editor.insertAtCaret(item.readableId)
@@ -114,9 +124,6 @@ export default class TextInput extends Component{
 
   _onKeyDown(e) {
     e.stopPropagation()
-    if (e.which === 27 || e.which === 13) {
-      this.props.onEscape()
-    }
   }
 
   render() {
@@ -131,6 +138,7 @@ export default class TextInput extends Component{
         onChange={this._handleChange.bind(this)}
         onFocus={this._handleFocus.bind(this)}
         onKeyDown={this._onKeyDown.bind(this)}
+        handleReturn={this.props.onEscape}
         value={this.props.value}
         placeholder={'value'}
         ref='editor'

--- a/src/components/distributions/editor/TextForm/TextInput.js
+++ b/src/components/distributions/editor/TextForm/TextInput.js
@@ -34,8 +34,7 @@ class TextInputEditor extends Component {
   }
 
   handleReturn(e) {
-    const shifted = e.shiftKey
-    if (shifted) {
+    if (e.shiftKey) {
       return false
     } else {
       this.props.handleReturn()

--- a/src/components/lib/FlowGrid/cell-empty.js
+++ b/src/components/lib/FlowGrid/cell-empty.js
@@ -16,6 +16,7 @@ export default class EmptyCell extends Component {
   _handleKeyDown(e) {
     if (e.keyCode == '13' && this.props.inSelectedCell) { //enter
       this.props.onAddItem(this.props.location)
+      e.preventDefault()
     }
     if (e.keyCode == '8') { //backspace
       e.preventDefault()

--- a/src/components/metrics/card/MetricCardViewSection/index.js
+++ b/src/components/metrics/card/MetricCardViewSection/index.js
@@ -107,6 +107,7 @@ export default class MetricCardViewSection extends Component {
                 name={metric.name}
                 onChange={onChangeName}
                 jumpSection={jumpSection}
+                onEscape={this.props.onEscape}
                 ref='name'
                 heightHasChanged={this.props.heightHasChanged}
               />

--- a/src/components/metrics/card/MetricCardViewSection/index.js
+++ b/src/components/metrics/card/MetricCardViewSection/index.js
@@ -39,6 +39,10 @@ export default class MetricCardViewSection extends Component {
     }
   }
 
+  focusName() {
+    this.refs.name && this.refs.name.focus()
+  }
+
   _shouldShowStatistics() {
     const isScientific = (this.props.canvasState.metricCardView === 'scientific')
     const isAvailable = this.showSimulation() && (_.get(this.props, 'metric.simulation.stats').length > 1)

--- a/src/components/metrics/card/index.js
+++ b/src/components/metrics/card/index.js
@@ -79,6 +79,12 @@ export default class MetricCard extends Component {
     }
   }
 
+  componentDidMount() {
+    if (this.props.inSelectedCell && this._isEmpty()) {
+      this.refs.MetricCardViewSection.focusName()
+    }
+  }
+
   openModal() {
     this.setState({modalIsOpen: true});
   }

--- a/src/components/metrics/card/index.js
+++ b/src/components/metrics/card/index.js
@@ -250,6 +250,7 @@ export default class MetricCard extends Component {
               showSensitivitySection={shouldShowSensitivitySection}
               editable={this.props.hovered}
               heightHasChanged={this.props.forceFlowGridUpdate}
+              onEscape={this.focus.bind(this)}
           />
 
           {inSelectedCell && !this.state.modalIsOpen &&

--- a/src/components/metrics/card/name/index.js
+++ b/src/components/metrics/card/name/index.js
@@ -30,8 +30,7 @@ class NameEditor extends Component {
   }
 
   handleReturn(e) {
-    const shifted = e.shiftKey
-    if (shifted) {
+    if (e.shiftKey) {
       return false
     } else {
       this.props.handleReturn()

--- a/src/components/metrics/card/name/index.js
+++ b/src/components/metrics/card/name/index.js
@@ -48,6 +48,7 @@ class NameEditor extends Component {
           onBlur={this.props.onBlur}
           onChange={this._onChange.bind(this)}
           handleReturn={this.handleReturn.bind(this)}
+          onEscape={this.props.onEscape}
           tabIndex={2}
           ref='editor'
           placeholder={this.props.placeholder}
@@ -118,6 +119,7 @@ export default class MetricName extends Component {
           onBlur={this.handleSubmit.bind(this)}
           value={this.state.value}
           handleReturn={this.props.jumpSection}
+          onEscape={this.props.onEscape}
           placeholder={'name'}
           isClickable={isClickable}
           ref='NameEditor'

--- a/src/components/metrics/card/name/index.js
+++ b/src/components/metrics/card/name/index.js
@@ -29,6 +29,16 @@ class NameEditor extends Component {
     return this.state.editorState.getCurrentContent().getPlainText('')
   }
 
+  handleReturn(e) {
+    const shifted = e.shiftKey
+    if (shifted) {
+      return false
+    } else {
+      this.props.handleReturn()
+      return true
+    }
+  }
+
   render() {
     const {editorState} = this.state;
     return (
@@ -37,6 +47,7 @@ class NameEditor extends Component {
           editorState={editorState}
           onBlur={this.props.onBlur}
           onChange={this._onChange.bind(this)}
+          handleReturn={this.handleReturn.bind(this)}
           tabIndex={2}
           ref='editor'
           placeholder={this.props.placeholder}
@@ -76,7 +87,7 @@ export default class MetricName extends Component {
   }
 
   _hasChanged() {
-    return (this.value() != this.props.name)
+    return ((this.value() || '') != (this.props.name || ''))
   }
 
   hasContent() {
@@ -87,15 +98,13 @@ export default class MetricName extends Component {
     return this.refs.NameEditor.getPlainText()
   }
 
+  focus() {
+    this.refs.NameEditor.focus()
+  }
+
   handleKeyDown(e) {
     e.stopPropagation()
     this.props.heightHasChanged()
-    // TODO(Ozzie): The code below currently doesn't work; kept here for potential future use.
-    const ENTER = (e) => ((e.keyCode === 13) && !e.shiftKey)
-    if (ENTER(e)){
-      e.stopPropagation()
-      this.props.jumpSection()
-    }
   }
 
   render() {
@@ -108,6 +117,7 @@ export default class MetricName extends Component {
         <NameEditor
           onBlur={this.handleSubmit.bind(this)}
           value={this.state.value}
+          handleReturn={this.props.jumpSection}
           placeholder={'name'}
           isClickable={isClickable}
           ref='NameEditor'


### PR DESCRIPTION
- For metric name, 'return' key selects value field.  Shift-return goes to a newline.
- For value field, 'return' key selects metric card.  Shift-return goes to a newline.
- Empty selected cards start off with name fields being selected.

Example currently on stage:
http://stage.getguesstimate.com/