### PR TITLE
View options needs to reset both on mount and update

### DIFF
--- a/src/components/spaces/show/index.js
+++ b/src/components/spaces/show/index.js
@@ -50,6 +50,18 @@ export default class SpacesShow extends Component {
   componentWillMount() {
     this.considerFetch(this.props)
     if (!this.props.embed) { elev.show() }
+
+    if (_.has(this.props, 'denormalizedSpace.editableByMe')) {
+      this.setDefaultEditPermission(_.get(this.props, 'denormalizedSpace.editableByMe'))
+    }
+  }
+
+  setDefaultEditPermission(editableByMe) {
+    if (!!editableByMe) {
+      this.props.dispatch(allowEdits())
+    } else {
+      this.props.dispatch(forbidEdits())
+    }
   }
 
   componentWillUnmount() {
@@ -60,11 +72,7 @@ export default class SpacesShow extends Component {
     const nextEditableState = _.get(nextProps, 'denormalizedSpace.editableByMe')
     const currEditableState = _.get(this.props, 'denormalizedSpace.editableByMe')
     if (nextEditableState !== currEditableState) {
-      if (!!nextEditableState) {
-        this.props.dispatch(allowEdits())
-      } else {
-        this.props.dispatch(forbidEdits())
-      }
+      this.setDefaultEditPermission(nextEditableState)
     }
   }
 


### PR DESCRIPTION
Otherwise changing spaces to an already loaded space doesn't reset the canvasState to the correct value. A cleaner solution (perhaps for a later refactor) would be to have an 'unset' value for the `editsAllowed` property, to which space dismount returned it.