### PR TITLE
Making a new model should reset you to edit mode if you start in view mode.

### DIFF
--- a/src/components/spaces/show/index.js
+++ b/src/components/spaces/show/index.js
@@ -71,7 +71,9 @@ export default class SpacesShow extends Component {
   componentWillReceiveProps(nextProps) {
     const nextEditableState = _.get(nextProps, 'denormalizedSpace.editableByMe')
     const currEditableState = _.get(this.props, 'denormalizedSpace.editableByMe')
-    if (nextEditableState !== currEditableState) {
+    const nextId = _.get(nextProps, 'spaceId')
+    const currId = _.get(this.props, 'spaceId')
+    if (nextId !== currId || nextEditableState !== currEditableState) {
       this.setDefaultEditPermission(nextEditableState)
     }
   }


### PR DESCRIPTION
When you make a new space, the 'editableByMe prop doesn't necessarily change, just the id does, (but we need the editableByMe prop check for when you load a space fresh, as there is no update where the id changes).