### PR TITLE
Saving data in the text form should run simulations.

### DIFF
--- a/src/components/distributions/editor/DataForm/DataForm.js
+++ b/src/components/distributions/editor/DataForm/DataForm.js
@@ -3,8 +3,8 @@ import React, {Component} from 'react'
 import {SmallDataViewer, LargeDataViewer} from './DataViewer'
 
 export default class DataForm extends Component{
-  _handleDelete() { this.props.onSave({guesstimateType: null, data: null, input: null}) }
-  _handleSave(data) { this.props.onSave({guesstimateType: 'DATA', data, input: null}) }
+  _handleDelete() { this.props.onSave({guesstimateType: null, data: null, input: null}, true) }
+  _handleSave(data) { this.props.onSave({guesstimateType: 'DATA', data, input: null}, true) }
 
   render() {
     const {size, data, onOpen} = this.props

--- a/src/components/distributions/editor/DataForm/DataViewer.js
+++ b/src/components/distributions/editor/DataForm/DataViewer.js
@@ -119,7 +119,7 @@ class Editor extends Component{
 
 const Viewer = ({data}) => (
   <ul>
-    {data.map((element, index) => {
+    {_.map(data, (element, index) => {
       return (
         <li key={index}>
           <DataPoint point={element} key={index}/>

--- a/src/components/distributions/editor/TextForm/TextForm.js
+++ b/src/components/distributions/editor/TextForm/TextForm.js
@@ -50,7 +50,7 @@ export default class TextForm extends Component{
     this.props.onChangeClickMode(newMode)
   }
 
-  _saveData(data) { this.props.onSave({guesstimateType: 'DATA', data, input: null}) }
+  _saveData(data) { this.props.onSave({guesstimateType: 'DATA', data, input: null}, true) }
 
   _shouldDisplayType() {
     const type = this._guesstimateType()

--- a/src/components/distributions/editor/index.js
+++ b/src/components/distributions/editor/index.js
@@ -29,11 +29,11 @@ export default class Guesstimate extends Component{
   _handleChange(params, runSimulations=true, registerGraphChange=false) {
     this.props.dispatch(changeGuesstimate(this.props.metricId, {...this.props.guesstimate, ...params}, runSimulations, registerGraphChange))
   }
-  _handleSave(params) {
-    if (!_.isEmpty(params)) {this._handleChange(params, false, true)}
+  _handleSave(params, runSimulations=false) {
+    if (!_.isEmpty(params)) {this._handleChange(params, runSimulations, true)}
   }
   _changeMetricClickMode(newMode) { this.props.dispatch(changeMetricClickMode(newMode)) }
-  _addDefaultData() { this._handleSave({guesstimateType: 'DATA', data:[1,2,3], input: null}) }
+  _addDefaultData() { this._handleSave({guesstimateType: 'DATA', data:[1,2,3], input: null}, true) }
 
   render () {
     const {size, guesstimate, onOpen, errors} = this.props


### PR DESCRIPTION
Also changes from `*.map(` syntax to `_.map(*, ` syntax to avoid SI infinite recursion errors in dev.