### PR TITLE
Track performance in dev.

### DIFF
--- a/src/lib/propagation/graph-propagation.js
+++ b/src/lib/propagation/graph-propagation.js
@@ -22,6 +22,9 @@ export class GraphPropagation {
   // metricId, samples
 
   constructor(dispatch: Function, getState: Function, graphFilters: object) {
+    if (__DEV__) {
+      window.Perf.start()
+    }
     this.dispatch = dispatch
     this.getState = getState
     this.id = Date.now()
@@ -52,6 +55,9 @@ export class GraphPropagation {
 
   run(): void {
     if (this.currentStep >= this.totalSteps) {
+      if (__DEV__) {
+        window.Perf.stop()
+      }
       return
     }
     this._step().then(() => {this.run()});

--- a/src/routes/app.js
+++ b/src/routes/app.js
@@ -7,6 +7,7 @@ import {setupGuesstimateApi} from 'servers/guesstimate-api/constants.js'
 import './main.css'
 import * as elev from 'server/elev/index.js'
 
+
 import Worker from 'worker!../lib/guesstimator/samplers/simulator-worker/index.js'
 window.workers = [new Worker, new Worker]
 
@@ -36,6 +37,11 @@ window.workers = window.workers.map(
 
 app.extend({
   init () {
+
+    if (__DEV__) {
+      window.Perf = require('react-addons-perf')
+    }
+
     window.intercomSettings = {
       app_id: "o0trb1v9"
     };


### PR DESCRIPTION
With these changes, in the console, you can simply run Perf.printWasted() and it will print the timings from the last propagation run.