### PR TITLE
Allow prefixes to be used in specifying points and ranges.

### DIFF
--- a/src/lib/guesstimator/formatter/formatters/lib.js
+++ b/src/lib/guesstimator/formatter/formatters/lib.js
@@ -1,4 +1,19 @@
-export function parseNumber(n) { return parseFloat(n) }
+const PREFIXES = {
+  'K': 3,
+  'M': 6,
+  'B': 9,
+  'T': 12,
+}
+
+const getZeros = prefix => Array.apply(null, Array(PREFIXES[prefix])).map(e => 0).join('')
+
+export function parseNumber(n) {
+  let numberStr = n
+  Object.keys(PREFIXES).forEach( prefix => {
+    numberStr = numberStr.replace(prefix, getZeros(prefix))
+  })
+  return parseFloat(numberStr)
+}
 
 export function isParseableNumber(n) {
   if (_.isString(n)){

--- a/src/lib/guesstimator/formatter/formatters/tests/DistributionNormalTextUpTo-test.js
+++ b/src/lib/guesstimator/formatter/formatters/tests/DistributionNormalTextUpTo-test.js
@@ -24,7 +24,7 @@ describe('DistributionTextUpTo', () => {
       [{text: '8:10'}, {guesstimateType: 'LOGNORMAL', low: 8, high: 10}],
       [{text: '0:5'}, {guesstimateType: 'NORMAL', low: 0, high: 5}],
       [{text: '8:10', guesstimateType: 'UNIFORM'}, {guesstimateType: 'UNIFORM', low: 8, high: 10}],
-      [{text: '8:10', guesstimateType: 'NORMAL'}, {guesstimateType: 'NORMAL', low: 8, high: 10}],
+      [{text: '8K:10M', guesstimateType: 'NORMAL'}, {guesstimateType: 'NORMAL', low: 8000, high: 10000000}],
       [{text: '-5:5', guesstimateType: 'NORMAL'}, {guesstimateType: 'NORMAL', low: -5, high: 5}],
       [{text: '0:5', guesstimateType: 'NORMAL'}, {guesstimateType: 'NORMAL', low: 0, high: 5}],
     ]

--- a/src/lib/guesstimator/formatter/formatters/tests/DistributionPointText-test.js
+++ b/src/lib/guesstimator/formatter/formatters/tests/DistributionPointText-test.js
@@ -18,7 +18,7 @@ describe("DistributionPointText", () => {
   describe('#format', () => {
     const examples = [
       [{text: '3'}, {guesstimateType: 'POINT', value: 3}],
-      [{text: 3}, {guesstimateType: 'POINT', value: 3}],
+      [{text: '3K'}, {guesstimateType: 'POINT', value: 3000}],
     ]
 
     const itExamples = examples.map(e => () => {


### PR DESCRIPTION
Supports:
'K' (* 10^3)
'M' (* 10^6)
'B' (* 10^9)
'T' (* 10^12)