### PR TITLE
Add performance timers in the development client.

### DIFF
--- a/src/components/lib/FlowGrid/FlowGrid.jsx
+++ b/src/components/lib/FlowGrid/FlowGrid.jsx
@@ -209,15 +209,26 @@ export default class FlowGrid extends Component{
     )
   }
 
+  componentDidMount() {
+    if (__DEV__) { window.RecordMountEvent(this) }
+  }
+
+  componentWillUpdate() {
+    if (__DEV__) { window.RecordRenderStartEvent(this) }
+  }
+
   componentDidUpdate() {
     const newHeights = upto(this._rowCount()).map(rowI => _.get(this.refs[`row-${rowI}`], 'offsetHeight'))
     if (!_.isEqual(newHeights, this.state.rowHeights)){
       this.setState({rowHeights: newHeights})
     }
+
+    if (__DEV__) { window.RecordRenderStopEvent(this) }
   }
 
   componentWillUnmount() {
     this.props.onDeSelectAll()
+    if (__DEV__) { window.RecordUnmountEvent(this) }
   }
 
   render() {

--- a/src/components/lib/FlowGrid/FlowGrid.jsx
+++ b/src/components/lib/FlowGrid/FlowGrid.jsx
@@ -59,6 +59,7 @@ export default class FlowGrid extends Component{
   }
 
   _handleMouseLeave(e) {
+    if (__DEV__) { window.RecordNamedEvent("FlowGrid set hover state") }
     this.setState({
       hover: {row: -1, column: -1},
       leftDown: false,
@@ -67,12 +68,14 @@ export default class FlowGrid extends Component{
 
   _handleMouseUp(e) {
     if (e.button === 0) {
+      if (__DEV__) { window.RecordNamedEvent("FlowGrid set left down state") }
       this.setState({leftDown: false})
     }
   }
 
   _handleEmptyCellMouseDown(e, location) {
     if (e.button === 0 && !(e.target && e.target.type === 'textarea')) {
+      if (__DEV__) { window.RecordNamedEvent("FlowGrid set left down state") }
       this.setState({leftDown: true})
       lastMousePosition = _.pick(e, 'pageX', 'pageY')
       e.preventDefault()
@@ -86,9 +89,11 @@ export default class FlowGrid extends Component{
 
   _handleCellMouseEnter(location, e) {
     if (this.state.leftDown && this._mouseMoved(e)) {
+      if (__DEV__) { window.RecordNamedEvent("FlowGrid set hover state") }
       this.setState({hover: {row: -1, column: -1}})
       this._handleEndRangeSelect(location)
     } else {
+      if (__DEV__) { window.RecordNamedEvent("FlowGrid set hover state") }
       this.setState({hover: location})
     }
   }
@@ -99,6 +104,7 @@ export default class FlowGrid extends Component{
 
   _handleKeyUp(e){
     if (e.keyCode == '17' || e.keyCode == '224' || e.keyCode == '91') {
+      if (__DEV__) { window.RecordNamedEvent("FlowGrid set ctrl pressed state") }
       this.setState({ctrlPressed: false})
     }
   }
@@ -126,6 +132,7 @@ export default class FlowGrid extends Component{
       this.props.onSelectItem(newLocation)
     } else if (!e.shiftKey && (e.keyCode == '17' || e.keyCode == '224' || e.keyCode == '91' || e.keyCode == '93')) {
       e.preventDefault()
+      if (__DEV__) { window.RecordNamedEvent("FlowGrid set ctrl pressed state") }
       this.setState({ctrlPressed: true})
     } else if (this.state.ctrlPressed) {
       if (e.keyCode == '86') {
@@ -218,17 +225,18 @@ export default class FlowGrid extends Component{
   }
 
   componentDidUpdate() {
+    if (__DEV__) { window.RecordRenderStopEvent(this) }
+
     const newHeights = upto(this._rowCount()).map(rowI => _.get(this.refs[`row-${rowI}`], 'offsetHeight'))
     if (!_.isEqual(newHeights, this.state.rowHeights)){
+      if (__DEV__) { window.RecordNamedEvent("FlowGrid set row heights state") }
       this.setState({rowHeights: newHeights})
     }
-
-    if (__DEV__) { window.RecordRenderStopEvent(this) }
   }
 
   componentWillUnmount() {
-    this.props.onDeSelectAll()
     if (__DEV__) { window.RecordUnmountEvent(this) }
+    this.props.onDeSelectAll()
   }
 
   render() {

--- a/src/components/lib/FlowGrid/cell.jsx
+++ b/src/components/lib/FlowGrid/cell.jsx
@@ -51,9 +51,20 @@ export default class Cell extends Component {
     return (difProps || itemDifferent || (bothHaveItems && this.props.hasItemUpdated(this.props.item, newProps.item)))
   }
 
+  componentWillUpdate() {
+    if (__DEV__) { window.RecordRenderStartEvent(this) }
+  }
+
+  componentWillUnmount() {
+    if (__DEV__) { window.RecordUnmountEvent(this) }
+  }
+
   componentDidUpdate(prevProps, prevState) {
     if ((!!prevProps.item !== !!this.props.item || !!prevProps.inSelectedCell !== !!this.props.inSelectedCell) && this.props.inSelectedCell) {
       this._focus()
+    }
+    if (__DEV__) {
+      window.RecordRenderStopEvent(this)
     }
   }
 
@@ -104,6 +115,9 @@ export default class Cell extends Component {
   componentDidMount() {
     if (this.props.inSelectedCell) {
       this._focus()
+    }
+    if (__DEV__) {
+      window.RecordMountEvent(this)
     }
   }
 

--- a/src/components/lib/FlowGrid/filled-cell.js
+++ b/src/components/lib/FlowGrid/filled-cell.js
@@ -31,6 +31,11 @@ export default class ItemCell extends Component {
     location: PTLocation.isRequired,
   }
 
+  componentDidMount() { if (__DEV__) { window.RecordMountEvent(this) } }
+  componentWillUpdate() { if (__DEV__) { window.RecordRenderStartEvent(this) } }
+  componentDidUpdate() { if (__DEV__) { window.RecordRenderStopEvent(this) } }
+  componentWillUnmount() { if (__DEV__) { window.RecordUnmountEvent(this) } }
+
   item() {
     return React.cloneElement(
         this.props.item,

--- a/src/components/metrics/card/index.js
+++ b/src/components/metrics/card/index.js
@@ -70,17 +70,22 @@ export default class MetricCard extends Component {
     return hasMetricUpdated(this.props, nextProps) || (this.state.modalIsOpen !== nextState.modalIsOpen)
   }
 
+  componentWillUpdate() { if (__DEV__) { window.RecordRenderStartEvent(this) } }
+  componentWillUnmount() { if (__DEV__) { window.RecordUnmountEvent(this) } }
+
   componentDidUpdate() {
     const hasContent = this.refs.MetricCardViewSection.hasContent()
     if (!this.props.inSelectedCell && this._isEmpty() && !hasContent && !this.state.modalIsOpen){
       this.handleRemoveMetric()
     }
+    if (__DEV__) { window.RecordRenderStopEvent(this) }
   }
 
   componentDidMount() {
     if (this.props.inSelectedCell && this._isEmpty()) {
       this.refs.MetricCardViewSection.focusName()
     }
+    if (__DEV__) { window.RecordMountEvent(this) }
   }
 
   openModal() {

--- a/src/components/spaces/canvas/index.js
+++ b/src/components/spaces/canvas/index.js
@@ -68,6 +68,12 @@ export default class Canvas extends Component{
     if (this.props.screenshot) {
       this.props.dispatch(canvasStateActions.change({metricCardView: 'display'}))
     }
+
+    if (__DEV__) { window.RecordMountEvent(this) }
+  }
+
+  componentWillUpdate() {
+    if (__DEV__) { window.RecordRenderStartEvent(this) }
   }
 
   componentDidUpdate(prevProps) {
@@ -76,10 +82,13 @@ export default class Canvas extends Component{
     if ((oldMetrics.length === 0) && (metrics.length > 0)){
       this.props.dispatch(runSimulations({spaceId: this.props.denormalizedSpace.id}))
     }
+
+    if (__DEV__) { window.RecordRenderStopEvent(this) }
   }
 
   componentWillUnmount(){
     this.props.dispatch(deleteSimulations(this.props.denormalizedSpace.metrics.map(m => m.id)))
+    if (__DEV__) { window.RecordUnmountEvent(this) }
   }
 
   _handleUndo() {

--- a/src/components/spaces/denormalized-space-selector.js
+++ b/src/components/spaces/denormalized-space-selector.js
@@ -14,9 +14,16 @@ function checkpointMetadata(id, checkpoints) {
   return attributes
 }
 
-const spaceGraphSelector = state => { return _.pick(state, 'spaces', 'metrics', 'guesstimates', 'simulations', 'users', 'organizations', 'userOrganizationMemberships', 'me', 'checkpoints') }
-const spaceSelector = (state, props) => {return state.spaces.find(s => _sameId(s.id, props.spaceId))}
-const canvasStateSelector = state => {return state.canvasState}
+let time = 0
+const spaceGraphSelector = state => {
+  if (__DEV__) {
+    window.RecordNamedEvent("Denormalized Space Selector Start")
+    time = (new Date()).getTime()
+  }
+  return _.pick(state, 'spaces', 'metrics', 'guesstimates', 'simulations', 'users', 'organizations', 'userOrganizationMemberships', 'me', 'checkpoints')
+}
+const spaceSelector = (state, props) => state.spaces.find(s => _sameId(s.id, props.spaceId))
+const canvasStateSelector = state => state.canvasState
 
 export const denormalizedSpaceSelector = createSelector(
   spaceGraphSelector,
@@ -38,6 +45,14 @@ export const denormalizedSpaceSelector = createSelector(
       })
     }
 
+    if (__DEV__) {
+      window.RecordNamedEvent("Denormalized Space Selector End")
+      if (!window.Paused) {
+        window.SelectorCounts["Denormalized Space Selector"] = (window.SelectorCounts["Denormalized Space Selector"] || 0) + 1
+        window.SelectorTimings["Denormalized Space Selector"] = (window.SelectorTimings["Denormalized Space Selector"] || []).concat((new Date()).getTime() - time)
+      }
+      time = 0
+    }
     return {
       denormalizedSpace: dSpace
     };

--- a/src/components/spaces/denormalized-space-selector.js
+++ b/src/components/spaces/denormalized-space-selector.js
@@ -1,6 +1,8 @@
 import { createSelector } from 'reselect';
 import e from 'gEngine/engine'
 
+const NAME = "Denormalized Space Selector"
+
 function _sameId(idA, idB){
   return idA.toString() === idB.toString()
 }
@@ -14,11 +16,9 @@ function checkpointMetadata(id, checkpoints) {
   return attributes
 }
 
-let time = 0
 const spaceGraphSelector = state => {
   if (__DEV__) {
-    window.RecordNamedEvent("Denormalized Space Selector Start")
-    time = (new Date()).getTime()
+    window.RecordSelectorStart(NAME)
   }
   return _.pick(state, 'spaces', 'metrics', 'guesstimates', 'simulations', 'users', 'organizations', 'userOrganizationMemberships', 'me', 'checkpoints')
 }
@@ -46,12 +46,7 @@ export const denormalizedSpaceSelector = createSelector(
     }
 
     if (__DEV__) {
-      window.RecordNamedEvent("Denormalized Space Selector End")
-      if (!window.Paused) {
-        window.SelectorCounts["Denormalized Space Selector"] = (window.SelectorCounts["Denormalized Space Selector"] || 0) + 1
-        window.SelectorTimings["Denormalized Space Selector"] = (window.SelectorTimings["Denormalized Space Selector"] || []).concat((new Date()).getTime() - time)
-      }
-      time = 0
+      window.RecordSelectorStop(NAME)
     }
     return {
       denormalizedSpace: dSpace

--- a/src/components/spaces/show/Toolbar/index.js
+++ b/src/components/spaces/show/Toolbar/index.js
@@ -44,6 +44,11 @@ const ProgressMessage = ({actionState}) => (
 )
 
 export class SpaceToolbar extends Component {
+  componentDidMount() { if (__DEV__) { window.RecordMountEvent(this) } }
+  componentWillUpdate() { if (__DEV__) { window.RecordRenderStartEvent(this) } }
+  componentDidUpdate() { if (__DEV__) { window.RecordRenderStopEvent(this) } }
+  componentWillUnmount() { if (__DEV__) { window.RecordUnmountEvent(this) } }
+
   shouldComponentUpdate(nextProps) {
     if (!nextProps.editableByMe) { return false }
     return (

--- a/src/components/spaces/show/header.js
+++ b/src/components/spaces/show/header.js
@@ -10,6 +10,11 @@ import e from 'gEngine/engine'
 import './header.css'
 
 export class SpaceHeader extends Component {
+  componentDidMount() { if (__DEV__) { window.RecordMountEvent(this) } }
+  componentWillUpdate() { if (__DEV__) { window.RecordRenderStartEvent(this) } }
+  componentDidUpdate() { if (__DEV__) { window.RecordRenderStopEvent(this) } }
+  componentWillUnmount() { if (__DEV__) { window.RecordUnmountEvent(this) } }
+
   shouldComponentUpdate(nextProps, nextState) {
     if (!nextProps.editableByMe) { return false }
 

--- a/src/components/spaces/show/index.js
+++ b/src/components/spaces/show/index.js
@@ -55,6 +55,10 @@ export default class SpacesShow extends Component {
   }
 
   componentWillMount() {
+    if (__DEV__) {
+      window.RecordMountEvent(this)
+    }
+
     this.considerFetch(this.props)
     if (!this.props.embed) { elev.show() }
 
@@ -72,6 +76,10 @@ export default class SpacesShow extends Component {
   }
 
   componentWillUnmount() {
+    if (__DEV__) {
+      window.RecordUnmountEvent(this)
+    }
+
     if (!this.props.embed) { elev.hide() }
   }
 
@@ -85,7 +93,17 @@ export default class SpacesShow extends Component {
     }
   }
 
+  componentWillUpdate() {
+    if (__DEV__) {
+      window.RecordRenderStartEvent(this)
+    }
+  }
+
   componentDidUpdate(prevProps) {
+    if (__DEV__) {
+      window.RecordRenderStopEvent(this)
+    }
+
     this.considerFetch(prevProps)
   }
 

--- a/src/components/spaces/show/sidebar.js
+++ b/src/components/spaces/show/sidebar.js
@@ -5,6 +5,11 @@ import {MarkdownViewer} from 'gComponents/utility/markdown-viewer/index.js'
 import {ButtonClose} from 'gComponents/utility/buttons/close'
 
 export class SpaceSidebar extends Component {
+  componentDidMount() { if (__DEV__) { window.RecordMountEvent(this) } }
+  componentWillUpdate() { if (__DEV__) { window.RecordRenderStartEvent(this) } }
+  componentDidUpdate() { if (__DEV__) { window.RecordRenderStopEvent(this) } }
+  componentWillUnmount() { if (__DEV__) { window.RecordUnmountEvent(this) } }
+
   shouldComponentUpdate(nextProps) {
     return nextProps.canEdit !== this.props.canEdit || this.props.description !== nextProps.description
   }

--- a/src/modules/reducers.js
+++ b/src/modules/reducers.js
@@ -23,6 +23,12 @@ export function changeSelect(location) {
 }
 
 const rootReducer = function app(state = {}, action){
+  if (__DEV__) {
+    window.RecordNamedEvent(action.type + " Reducing")
+    if (!window.Paused) {
+      window.ActionCounts[action.type] = (window.ActionCounts[action.type] || 0) + 1
+    }
+  }
   return {
     displayError: SI(displayErrorR(state.displayError, action)),
     metrics: SI(metricsR(state.metrics, action)),

--- a/src/routes/app.js
+++ b/src/routes/app.js
@@ -74,6 +74,7 @@ app.extend({
         const lastElm = list[list.length - 1]
         if (lastElm.name === name) {
           lastElm.end = time
+          lastElm.duration = lastElm.end - lastElm.start
         } else {
           appendStopToNestedList(name, time, lastElm.children)
         }

--- a/src/routes/app.js
+++ b/src/routes/app.js
@@ -40,6 +40,54 @@ app.extend({
 
     if (__DEV__) {
       window.Perf = require('react-addons-perf')
+      window.AppStartTime = (new Date()).getTime()
+      window.Timeline = [{name: "Application Start", time: window.AppStartTime}]
+      window.RenderCounts = {}
+      window.RenderTimings = {}
+      window.SelectorCounts = {}
+      window.SelectorTimings = {}
+      window.ActionCounts = {}
+      window.ActionTimings = {}
+      window.Paused = false
+
+      window.RecordNamedEvent = (name) => {
+        if (window.Paused) { return }
+        window.Timeline = window.Timeline.concat({
+          name,
+          time: (new Date()).getTime() - AppStartTime
+        })
+      }
+
+      window.RecordMountEvent = (component) => { window.RecordNamedEvent(component.constructor.name + " Mount") }
+      window.RecordUnmountEvent = (component) => { window.RecordNamedEvent(component.constructor.name + " Unmount") }
+      window.RecordRenderStartEvent = (component) => {
+        if (window.Paused) { return }
+        const name = component.constructor.name
+        window.RecordNamedEvent(name + " Render Start")
+
+        const time = (new Date()).getTime()
+        window.RenderTimings[name] = (window.RenderTimings[name] || []).concat(time)
+      }
+      window.RecordRenderStopEvent = (component) => {
+        if (window.Paused) { return }
+        const name = component.constructor.name
+        window.RecordNamedEvent(name + " Render Stop")
+
+        const time = (new Date()).getTime()
+        window.RenderCounts[name] = (window.RenderCounts[name] || 0) + 1
+        window.RenderTimings[name] = window.RenderTimings[name].slice(0,-1).concat(time - window.RenderTimings[name][window.RenderTimings[name].length-1])
+      }
+      window.ClearRecordings = () => {
+        window.Timeline = []
+        window.RenderCounts = {}
+        window.RenderTimings = {}
+        window.ActionCounts = {}
+        window.ActionTimings = {}
+        window.SelectorCounts = {}
+        window.SelectorTimings = {}
+      }
+      window.PauseRecordings = () => { window.Paused = true }
+      window.UnpauseRecordings = () => { window.Paused = false }
     }
 
     window.intercomSettings = {

--- a/src/routes/app.js
+++ b/src/routes/app.js
@@ -40,16 +40,19 @@ app.extend({
 
     if (__DEV__) {
       window.Perf = require('react-addons-perf')
-      window.AppStartTime = (new Date()).getTime()
-      window.Timeline = [{name: "Application Start", time: window.AppStartTime}]
-      window.NestedTimeline = [{name: "Application Start", time: window.AppStartTime, end: true}]
-      window.RenderCounts = {}
-      window.RenderTimings = {}
-      window.SelectorCounts = {}
-      window.SelectorTimings = {}
-      window.ActionCounts = {}
-      window.ActionTimings = {}
       window.Paused = false
+      window.ClearRecordings = () => {
+        window.AppStartTime = (new Date()).getTime()
+        window.Timeline = [{name: "Application Start", time: window.AppStartTime}]
+        window.NestedTimeline = [{name: "Application Start", time: window.AppStartTime, end: true}]
+        window.RenderCounts = {}
+        window.RenderTimings = {}
+        window.SelectorCounts = {}
+        window.SelectorTimings = {}
+        window.ActionCounts = {}
+        window.ActionTimings = {}
+      }
+      window.ClearRecordings()
 
       const appendSingletonToNestedList = (name, time, list) => {
         const lastElm = list[list.length - 1]
@@ -116,15 +119,6 @@ app.extend({
         const time = (new Date()).getTime()
         window.RenderCounts[name] = (window.RenderCounts[name] || 0) + 1
         window.RenderTimings[name] = window.RenderTimings[name].slice(0,-1).concat(time - window.RenderTimings[name][window.RenderTimings[name].length-1])
-      }
-      window.ClearRecordings = () => {
-        window.Timeline = []
-        window.RenderCounts = {}
-        window.RenderTimings = {}
-        window.ActionCounts = {}
-        window.ActionTimings = {}
-        window.SelectorCounts = {}
-        window.SelectorTimings = {}
       }
       window.PauseRecordings = () => { window.Paused = true }
       window.UnpauseRecordings = () => { window.Paused = false }

--- a/src/routes/app.js
+++ b/src/routes/app.js
@@ -71,6 +71,7 @@ app.extend({
         }
       }
       const appendStopToNestedList = (name, time, list) => {
+        if (!list) { console.warn("Failed to close timing for ", name, " at ", time); return }
         const lastElm = list[list.length - 1]
         if (lastElm.name === name) {
           lastElm.end = time


### PR DESCRIPTION
This records how long a variety of components take to render, how long the denormalized space selector takes to run, and when reducers are called.

