### PR TITLE
Fixes some jitteriness with background.

### DIFF
--- a/src/components/lib/FlowGrid/FlowGrid.jsx
+++ b/src/components/lib/FlowGrid/FlowGrid.jsx
@@ -287,7 +287,8 @@ export default class FlowGrid extends Component{
             }
               <BackgroundContainer
                 edges={edges}
-                rowHeights={_.map(upto(rowCount), (_r, i) => this._getRowHeight(i))}
+                rowCount={rowCount}
+                getRowHeight={this._getRowHeight.bind(this)}
                 selectedRegion={this.props.selectedRegion}
                 copiedRegion={this.props.copiedRegion}
               />

--- a/src/components/lib/FlowGrid/background-container.js
+++ b/src/components/lib/FlowGrid/background-container.js
@@ -7,6 +7,8 @@ import GridPoint from './gridPoints'
 
 import {PTRegion} from 'lib/locationUtils'
 
+const upto = (n) => Array.apply(null, {length: n})
+
 const Region = ({rowHeights, columnWidth, selectedRegion, type}) => {
   const gridPoint = new GridPoint({rowHeights, columnWidth, padding: 0})
   const region = gridPoint.region(selectedRegion)
@@ -20,10 +22,22 @@ export class BackgroundContainer extends Component {
   displayName: 'BackgroundContainer'
 
   static propTypes = {
-    rowHeights: PropTypes.array.isRequired,
+    rowCount: PropTypes.number.isRequired,
     edges: PropTypes.array.isRequired,
     selectedRegion: PTRegion,
     copiedRegion: PTRegion,
+  }
+
+  state = {
+    rowHeights: []
+  }
+
+  componentWillMount() {
+    this.setState({rowHeights: _.map(upto(this.props.rowCount), (r, i) => this.props.getRowHeight(i))})
+  }
+
+  componentWillReceiveProps(nextProps) {
+    this.setState({rowHeights: _.map(upto(nextProps.rowCount), (r, i) => nextProps.getRowHeight(i))})
   }
 
   shouldComponentUpdate(nextProps, nextState) {
@@ -31,12 +45,13 @@ export class BackgroundContainer extends Component {
       !_.isEqual(this.props.copiedRegion, nextProps.copiedRegion) ||
       !_.isEqual(this.props.selectedRegion, nextProps.selectedRegion) ||
       !_.isEqual(this.props.edges, nextProps.edges) ||
-      !_.isEqual(this.props.rowHeights, nextProps.rowHeights)
+      !_.isEqual(this.state.rowHeights, nextState.rowHeights)
     )
   }
 
   render() {
-    const {edges, rowHeights, getRowHeight, selectedRegion, copiedRegion} = this.props
+    const {edges, rowCount, getRowHeight, selectedRegion, copiedRegion} = this.props
+    const {rowHeights} = this.state
 
     const columnWidth = $('.FlowGridCell') && $('.FlowGridCell')[0] && $('.FlowGridCell')[0].offsetWidth
     if (!columnWidth || !rowHeights.length) { return false }


### PR DESCRIPTION
 If the state is calculated in Flowgrid, it is calculated on the previous incarnation of the rendered component. If it is calculated in the background container, that happens after the rows are rendered are thus gets the correct row heights.