### PR TITLE
Disable the recorder until a real fix is implemented.

### DIFF
--- a/src/lib/recorder.js
+++ b/src/lib/recorder.js
@@ -16,7 +16,7 @@ export class GuesstimateRecorder {
 
   constructor() {
     this.disabled = !__DEV__
-    this.paused = false
+    this.paused = true
     this.clearRecordings()
   }
 


### PR DESCRIPTION
The recorder breaks when multiple components of the same name render in parallel; the fix would be for each component instance to have a unique ID; this would take more time than is warranted right now but this change will stop the broken recorder from running general in dev mode.