### PR TITLE
Images shouldn't extend beyond the width of the calculator section.

### DIFF
--- a/src/components/calculators/style.css
+++ b/src/components/calculators/style.css
@@ -32,6 +32,10 @@
     margin-top: .9em;
     margin-bottom: 2em;
     color: #666;
+
+    img {
+      max-width: 100%;
+    }
   }
 
   .inputs {


### PR DESCRIPTION
Makes images that would look like this:
![calc-view-image-extension](https://cloud.githubusercontent.com/assets/470751/16363978/c174fcbe-3b90-11e6-81db-7c84e6a69ffe.png)
Look like this:
![calc-view-image-shrunk](https://cloud.githubusercontent.com/assets/470751/16363980/cc26e62c-3b90-11e6-939e-6303140b9304.png)
