### PR TITLE
Refactored formatters.

### DIFF
--- a/src/components/metrics/card/index.js
+++ b/src/components/metrics/card/index.js
@@ -206,8 +206,9 @@ export default class MetricCard extends Component {
 
   _errors() {
     if (this.props.isTitle){ return [] }
-    let errors = _.get(this.props.metric, 'simulation.sample.errors')
-    return errors ? errors.filter(e => !!e) : []
+    const errors = _.get(this.props.metric, 'simulation.sample.errors') || []
+    if (!_.isEmpty(errors)) {console.log(errors)}
+    return errors.filter(e => !!e)
   }
 
   _shouldShowSimulation(metric) {

--- a/src/components/metrics/card/index.js
+++ b/src/components/metrics/card/index.js
@@ -207,7 +207,6 @@ export default class MetricCard extends Component {
   _errors() {
     if (this.props.isTitle){ return [] }
     const errors = _.get(this.props.metric, 'simulation.sample.errors') || []
-    if (!_.isEmpty(errors)) {console.log(errors)}
     return errors.filter(e => !!e)
   }
 

--- a/src/lib/guesstimator/formatter/formatters/Data.js
+++ b/src/lib/guesstimator/formatter/formatters/Data.js
@@ -1,5 +1,3 @@
-import {textMixin, isParseableNumber, parseNumber} from './lib.js'
-
 export function formatData(value) {
   return value
     .replace(/[\[\]]/g, '')
@@ -13,16 +11,8 @@ export function formatData(value) {
 export const isData = input => !input.includes('=') && (input.match(/[\n\s,]/g) || []).length > 3
 
 export const item = {
-  guesstimateType: 'DATA',
-  inputType: 'TEXT',
   formatterName: 'DATA',
-
-  format(g) {
-    return {
-      guesstimateType: this.guesstimateType,
-      data: g.data
-    }
-  },
+  errors(g) { return [] },
   matches(g) { return !!g.data },
-  errors(g) {return []},
+  format(g) { return { guesstimateType: 'DATA', data: g.data } },
 }

--- a/src/lib/guesstimator/formatter/formatters/DistributionPointText.js
+++ b/src/lib/guesstimator/formatter/formatters/DistributionPointText.js
@@ -1,23 +1,15 @@
-import {textMixin, isParseableNumber, parseNumber} from './lib.js'
+import {parseNumber} from './lib.js'
 
-export const item = Object.assign(
-  {}, textMixin,
-  {
-    guesstimateType: 'POINT',
-    inputType: 'TEXT',
-    formatterName: 'DISTRIBUTION_POINT_TEXT',
-    errors(g) {
-      const value = parseNumber(g.text)
-      if (!_.isFinite(value) || !isParseableNumber(value)) {
-        return ['invalid sample']
-      }
-      return []
-    },
-    format(g) {
-      const {guesstimateType} = this
-      const value = parseNumber(g.text)
-      return {guesstimateType, value}
-    },
-    _matchesText(g) { return true },
-  }
-)
+const POINT_REGEX = /^\s*(\d*(?:\.\d+)?)\s?(M|B|K|T)?\s*$/
+
+export const item = {
+  formatterName: 'DISTRIBUTION_POINT_TEXT',
+  errors() { return [] },
+  matches({text}) { return POINT_REGEX.test(text) },
+  _number(text) {
+    const [_, num, suffix] = text.match(POINT_REGEX)
+    return parseNumber(num, suffix)
+  },
+  format({text}) { return {guesstimateType: "POINT", value: this._number(text)} }
+}
+

--- a/src/lib/guesstimator/formatter/formatters/DistributionPointText.js
+++ b/src/lib/guesstimator/formatter/formatters/DistributionPointText.js
@@ -1,15 +1,8 @@
-import {parseNumber} from './lib.js'
-
-const POINT_REGEX = /^\s*(\d*(?:\.\d+)?)\s?(M|B|K|T)?\s*$/
+import {regexBasedFormatter, POINT_REGEX} from './lib.js'
 
 export const item = {
   formatterName: 'DISTRIBUTION_POINT_TEXT',
-  errors() { return [] },
-  matches({text}) { return POINT_REGEX.test(text) },
-  _number(text) {
-    const [_, num, suffix] = text.match(POINT_REGEX)
-    return parseNumber(num, suffix)
-  },
-  format({text}) { return {guesstimateType: "POINT", value: this._number(text)} }
+  guesstimateType() { return 'POINT' },
+  ...regexBasedFormatter(POINT_REGEX, () => []),
 }
 

--- a/src/lib/guesstimator/formatter/formatters/DistributionTextProportion.js
+++ b/src/lib/guesstimator/formatter/formatters/DistributionTextProportion.js
@@ -1,9 +1,7 @@
-import {regexBasedFormatter} from './lib.js'
-
-const PROPORTION_REGEX = /^\s*(\d*(?:\.\d+)?)\s?(M|B|K|T)?\s*(?:of|in)\s*(\d*(?:\.\d+)?)\s?(M|B|K|T)?\s*$/
+import {regexBasedFormatter, rangeRegex} from './lib.js'
 
 export const item = {
   formatterName: 'DISTRIBUTION_PROPORTIONALITY',
   guesstimateType() { return 'BETA' },
-  ...regexBasedFormatter(PROPORTION_REGEX, '1 of/in 10'),
+  ...regexBasedFormatter(rangeRegex(/of|in/)),
 }

--- a/src/lib/guesstimator/formatter/formatters/DistributionTextProportion.js
+++ b/src/lib/guesstimator/formatter/formatters/DistributionTextProportion.js
@@ -1,31 +1,9 @@
-import {parseNumber} from './lib.js'
+import {regexBasedFormatter} from './lib.js'
+
+const PROPORTION_REGEX = /^\s*(\d*(?:\.\d+)?)\s?(M|B|K|T)?\s*(?:of|in)\s*(\d*(?:\.\d+)?)\s?(M|B|K|T)?\s*$/
 
 export const item = {
-  inputType: 'TEXT',
   formatterName: 'DISTRIBUTION_PROPORTIONALITY',
-
-  separators: [' of ', ' in '],
-
-  errors(g) {
-    const numbers = this._numbers(g.text)
-    if (numbers.length !== 2) {
-      return ['only accepts two numbers']
-    } else if (numbers[1] < numbers[0]) {
-      return ['the second number must be greater than the first number']
-    }
-    return []
-  },
-
-  matchingSep(text) { return _.find(this.separators, s => text.includes(s)) },
-
-  matches({text}) { return !!text && _.isString(text) && !!this.matchingSep(text) },
-
-  _numbers(text) { return text.split(this.matchingSep(text)).map(e => parseNumber(e.trim())) },
-
-  format(g) {
-    const [hits, total] = this._numbers(g.text)
-    const guesstimateType = "BETA"
-    return {guesstimateType, hits, total}
-  }
+  guesstimateType() { return 'BETA' },
+  ...regexBasedFormatter(PROPORTION_REGEX, '1 of/in 10'),
 }
-

--- a/src/lib/guesstimator/formatter/formatters/DistributionTextUpTo.js
+++ b/src/lib/guesstimator/formatter/formatters/DistributionTextUpTo.js
@@ -1,16 +1,9 @@
-import {confidenceIntervalTextMixin} from './lib.js'
+import {getGuesstimateType, regexBasedFormatter} from './lib.js'
 
-export const item = Object.assign(
-  {}, confidenceIntervalTextMixin,
-  {
-    inputType: 'TEXT',
-    formatterName: 'DISTRIBUTION_NORMAL_TEXT_UPTO',
-    _symbols: ['->', ':', '..', 'to'],
-    _numbers(text) { return this._splitNumbersAt(text, this._relevantSymbol(text)) },
-    format(g) {
-      const [low, high] = this._numbers(g.text)
-      const guesstimateType = this.guesstimateType(g, low)
-      return {guesstimateType, low, high}
-    }
-  }
-)
+const RANGE_REGEX = /^\s*(\d*(?:\.\d+)?)\s?(M|B|K|T)?\s*(?:to|-|\.\.|->|:)\s*(\d*(?:\.\d+)?)\s?(M|B|K|T)?\s*$/
+
+export const item = {
+  formatterName: 'DISTRIBUTION_NORMAL_TEXT_UPTO',
+  guesstimateType(type, [low]) { return getGuesstimateType(type, low) },
+  ...regexBasedFormatter(RANGE_REGEX, '1 to 10'),
+}

--- a/src/lib/guesstimator/formatter/formatters/DistributionTextUpTo.js
+++ b/src/lib/guesstimator/formatter/formatters/DistributionTextUpTo.js
@@ -1,9 +1,7 @@
-import {getGuesstimateType, regexBasedFormatter} from './lib.js'
-
-const RANGE_REGEX = /^\s*(\d*(?:\.\d+)?)\s?(M|B|K|T)?\s*(?:to|-|\.\.|->|:)\s*(\d*(?:\.\d+)?)\s?(M|B|K|T)?\s*$/
+import {getGuesstimateType, regexBasedFormatter, rangeRegex} from './lib.js'
 
 export const item = {
   formatterName: 'DISTRIBUTION_NORMAL_TEXT_UPTO',
   guesstimateType(type, [low]) { return getGuesstimateType(type, low) },
-  ...regexBasedFormatter(RANGE_REGEX, '1 to 10'),
+  ...regexBasedFormatter(rangeRegex(/to|\.\.|->|:/)),
 }

--- a/src/lib/guesstimator/formatter/formatters/DistributionTextUpToAlternate.js
+++ b/src/lib/guesstimator/formatter/formatters/DistributionTextUpToAlternate.js
@@ -1,9 +1,7 @@
-import {getGuesstimateType, regexBasedFormatter} from './lib.js'
-
-const RANGE_REGEX = /^\s*\[\s*(\d*(?:\.\d+)?)\s?(M|B|K|T)?,\s*(\d*(?:\.\d+)?)\s?(M|B|K|T)?\s*\]\s*$/
+import {getGuesstimateType, regexBasedFormatter, rangeRegex} from './lib.js'
 
 export const item = {
   formatterName: 'DISTRIBUTION_NORMAL_TEXT_UPTO',
   guesstimateType(type, [low]) { return getGuesstimateType(type, low) },
-  ...regexBasedFormatter(RANGE_REGEX, '[1, 10]'),
+  ...regexBasedFormatter(rangeRegex(/,\s?/, /\[/, /\]/)),
 }

--- a/src/lib/guesstimator/formatter/formatters/DistributionTextUpToAlternate.js
+++ b/src/lib/guesstimator/formatter/formatters/DistributionTextUpToAlternate.js
@@ -1,18 +1,9 @@
-import {confidenceIntervalTextMixin} from './lib.js'
+import {getGuesstimateType, regexBasedFormatter} from './lib.js'
 
-export const item = Object.assign(
-  {}, confidenceIntervalTextMixin,
-  {
-    inputType: 'TEXT',
-    formatterName: 'DISTRIBUTION_NORMAL_TEXT_UPTO',
-    _symbols: ['['],
-    format(g) {
-      let [low, high] = this._numbers(g.text)
-      const guesstimateType = this.guesstimateType(g, low)
-      return {guesstimateType, low, high}
-    },
-    _numbers(text) {
-      return this._splitNumbersAt(text.replace('[', '').replace(']', ''), ',')
-    },
-  }
-)
+const RANGE_REGEX = /^\s*\[\s*(\d*(?:\.\d+)?)\s?(M|B|K|T)?,\s*(\d*(?:\.\d+)?)\s?(M|B|K|T)?\s*\]\s*$/
+
+export const item = {
+  formatterName: 'DISTRIBUTION_NORMAL_TEXT_UPTO',
+  guesstimateType(type, [low]) { return getGuesstimateType(type, low) },
+  ...regexBasedFormatter(RANGE_REGEX, '[1, 10]'),
+}

--- a/src/lib/guesstimator/formatter/formatters/Function.js
+++ b/src/lib/guesstimator/formatter/formatters/Function.js
@@ -1,21 +1,6 @@
-import {textMixin, isParseableNumber, parseNumber} from './lib.js'
-
-export const item = Object.assign(
-  {}, textMixin,
-  {
-    guesstimateType: 'FUNCTION',
-    inputType: 'TEXT',
-    formatterName: 'FUNCTION',
-    _matchesText(text) { return (text[0] === '=') },
-
-    format(g) {
-      return {
-        guesstimateType: this.guesstimateType,
-        text: this._formatText(g.text),
-      }
-    },
-
-    errors(g) {return []},
-    _formatText(text) { return text.substring(1, text.length) },
-  }
-)
+export const item = {
+  formatterName: 'FUNCTION',
+  matches({text}) { return !!text && text.startsWith('=') },
+  errors() {return []},
+  format({text}) { return {guesstimateType: 'FUNCTION', text: text.slice(1)} },
+}

--- a/src/lib/guesstimator/formatter/formatters/Null.js
+++ b/src/lib/guesstimator/formatter/formatters/Null.js
@@ -4,5 +4,5 @@ export const item = {
   formatterName: 'NULL',
   matches(g) { return true },
   format(g) { return {guesstimateType: 'NONE'} },
-  errors(g) { return [] },
+  errors({text}) { return _.isEmpty(text) ? [] : ['unrecognized input format'] },
 }

--- a/src/lib/guesstimator/formatter/formatters/lib.js
+++ b/src/lib/guesstimator/formatter/formatters/lib.js
@@ -1,9 +1,20 @@
-const PREFIXES = {
+const SUFFIXES = {
   'K': 3,
   'M': 6,
   'B': 9,
   'T': 12,
 }
+
+const SUFFIX_REGEX = new RegExp(Object.keys(SUFFIXES).join('|'))
+const INTEGER_REGEX = /\d+(?!\.)/
+const DECIMAL_REGEX = /\d*(?:\.\d+)+/
+const NUMBER_REGEX = new RegExp(`(-?(?:${INTEGER_REGEX.source})|(?:${DECIMAL_REGEX}))\\s?(${SUFFIX_REGEX.source})?`)
+
+const spaceSep = res => new RegExp(res.filter(re => !!re).map(re => `(?:${re.source})`).join('\\s*'))
+const padded = res => spaceSep([/^/, ...res, /$/])
+
+export const POINT_REGEX = padded([NUMBER_REGEX])
+export const rangeRegex = (sep, left, right) => padded([left, NUMBER_REGEX, sep, NUMBER_REGEX, right])
 
 // We assume that if the user started at 0 or tried a negative number,
 // they intended for this to be normal.
@@ -23,25 +34,21 @@ export function getGuesstimateType(guesstimateType, low) {
   }
 }
 
-const getMult = prefix => Math.pow(10,PREFIXES[prefix])
-export const parseNumber = (num, suffix) => parseFloat(num) * (!!suffix ? getMult(suffix) : 1)
+const getMult = suffix => Math.pow(10,SUFFIXES[suffix])
+const parseNumber = (num, suffix) => parseFloat(num) * (!!suffix ? getMult(suffix) : 1)
 
-export const regexBasedFormatter = (re, syntax) => ({
-  matches({text}) { return re.test(text) },
-  errors({text}) {
-    const [low, high] = this._numbers(text)
+const rangeErrorFn = ([low, high]) => low > high ? ['the low number should come first'] : []
 
-    if (!low || !high) {
-      return [`Syntax is '${syntax}'`]
-    } else if (high < low) {
-      return [`${high} should be > ${low}`]
-    }
-    return []
-  },
-  format({guesstimateType, text}) {
-    const params = this._numbers(text)
-    return {guesstimateType: this.guesstimateType(guesstimateType, params), params}
-  },
+export function regexBasedFormatter(re, errorFn = rangeErrorFn) {
+  return {
+    matches({text}) { return re.test(text) },
+    errors({text}) { return errorFn(this._numbers(text)) },
 
-  _numbers(text) { return _.chunk(text.match(re).slice(1), 2).map(([num, suffix]) => parseNumber(num, suffix)) },
-})
+    format({guesstimateType, text}) {
+      const params = this._numbers(text)
+      return {guesstimateType: this.guesstimateType(guesstimateType, params), params}
+    },
+
+    _numbers(text) { return _.chunk(text.match(re).slice(1), 2).map(([num, suffix]) => parseNumber(num, suffix)) },
+  }
+}

--- a/src/lib/guesstimator/formatter/formatters/lib.js
+++ b/src/lib/guesstimator/formatter/formatters/lib.js
@@ -5,90 +5,43 @@ const PREFIXES = {
   'T': 12,
 }
 
-const getMult = prefix => Math.pow(10,PREFIXES[prefix])
-
-export function parseNumber(n) {
-  let number = parseFloat(n)
-  Object.keys(PREFIXES).forEach( prefix => {
-    if (n.includes(prefix)) {
-      number = number * getMult(prefix)
-    }
-  })
-  return number
-}
-
-export function isParseableNumber(n) {
-  if (_.isString(n)){
-    return !isNaN(n)
-  } else {
-    return _.isFinite(n)
-  }
-}
-
-export const graphicalMixin = {
-  matches(g) {
-    return g.guesstimateType === this.guesstimateType
-  },
-
-  format(g) {
-    let output = {guesstimateType: this.guesstimateType}
-    this.relevantNumbers.map(e => {output[e.name] = parseNumber(g[e.name])})
-    return output
-  },
-
-  errors(g) {
-    const required = this.relevantNumbers.filter(e => e.required)
-    const requiredAndUnparseable = required.filter(r => !isParseable(g[r]))
-    return requiredAndUnparseable.map(e => `Unable to parse required attribute ${e.name}`)
-  }
-}
-
-export const textMixin = {
-  matches(g) {
-    return (this._hasText(g) && this._matchesText(g.text))
-  },
-
-  _hasText(g) {
-    return !!(g.text && _.isString(g.text))
-  }
-}
-
 // We assume that if the user started at 0 or tried a negative number,
 // they intended for this to be normal.
 const isNotLogNormal = low => (isFinite(low) && (low <= 0))
 
-export const confidenceIntervalTextMixin = Object.assign(
-  {}, textMixin,
-  {
-    errors(g) { return this._confidenceIntervalTextErrors(g.text) },
-    guesstimateType(g, low) {
-      switch (g.guesstimateType) {
-        case 'UNIFORM':
-          return g.guesstimateType
-        case 'NORMAL':
-          return g.guesstimateType
-        case 'LOGNORMAL':
-          return isNotLogNormal(low) ? 'NORMAL' : 'LOGNORMAL'
-        default:
-          if (!isFinite(low)) { return 'LOGNORMAL' }
-          return isNotLogNormal(low) ? 'NORMAL' : 'LOGNORMAL'
-      }
-    },
-    _matchesText(text) { return this._hasRelevantSymbol(text) },
-    _confidenceIntervalTextErrors(text) {
-      if (this._inputSymbols(text).length > 1) { return ['Must contain only 1 symbol'] }
-
-      const numbers = this._numbers(text)
-      if (numbers.length !== 2) { return ['Must contain 2 inputs'] }
-      if (!_.every(numbers, (e) => isParseableNumber(e))) { return ['Not all numbers are parseable'] }
-      if (numbers[0] >= numbers[1]) { return ['Low number must be first'] }
-
-      return []
-    },
-
-    _inputSymbols(text) { return this._symbols.filter(e => (text.includes(e))) },
-    _relevantSymbol(text) { return this._inputSymbols(text)[0] },
-    _hasRelevantSymbol(text) { return (this._inputSymbols(text).length > 0) },
-    _splitNumbersAt(text, symbol) { return text.split(symbol).map((e) => parseNumber(e.trim())); }
+export function getGuesstimateType(guesstimateType, low) {
+  switch (guesstimateType) {
+    case 'UNIFORM':
+      return guesstimateType
+    case 'NORMAL':
+      return guesstimateType
+    case 'LOGNORMAL':
+      return isNotLogNormal(low) ? 'NORMAL' : 'LOGNORMAL'
+    default:
+      if (!isFinite(low)) { return 'LOGNORMAL' }
+      return isNotLogNormal(low) ? 'NORMAL' : 'LOGNORMAL'
   }
-)
+}
+
+const getMult = prefix => Math.pow(10,PREFIXES[prefix])
+export const parseNumber = (num, suffix) => parseFloat(num) * (!!suffix ? getMult(suffix) : 1)
+
+export const regexBasedFormatter = (re, syntax) => ({
+  matches({text}) { return re.test(text) },
+  errors({text}) {
+    const [low, high] = this._numbers(text)
+
+    if (!low || !high) {
+      return [`Syntax is '${syntax}'`]
+    } else if (high < low) {
+      return [`${high} should be > ${low}`]
+    }
+    return []
+  },
+  format({guesstimateType, text}) {
+    const params = this._numbers(text)
+    return {guesstimateType: this.guesstimateType(guesstimateType, params), params}
+  },
+
+  _numbers(text) { return _.chunk(text.match(re).slice(1), 2).map(([num, suffix]) => parseNumber(num, suffix)) },
+})

--- a/src/lib/guesstimator/formatter/index.js
+++ b/src/lib/guesstimator/formatter/index.js
@@ -41,4 +41,3 @@ export function parse(g) {
   let format = errors.length ? {} : formatter.format(i)
   return [errors, format]
 }
-

--- a/src/lib/guesstimator/samplers/DistributionBeta.js
+++ b/src/lib/guesstimator/samplers/DistributionBeta.js
@@ -1,7 +1,7 @@
 import {simulate} from './Simulator.js'
 
 export var Sampler = {
-  sample({hits, total}, n) {
+  sample({params: [hits, total]}, n) {
     // This treats your entry as a prior, and assumes you are 2 times more confident than
     // a raw beta would be. This gives your distribution more of a peak for small numbers.
     return simulate(`beta(${2*hits},${2*(total-hits)})`, [], n)

--- a/src/lib/guesstimator/samplers/DistributionLognormal.js
+++ b/src/lib/guesstimator/samplers/DistributionLognormal.js
@@ -2,7 +2,7 @@ import math from 'mathjs'
 import {simulate} from './Simulator.js'
 
 export var Sampler = {
-  sample({high, low}, n) {
+  sample({params: [low, high]}, n) {
     // This assumes a centered 90% confidence interval, e.g. the left endpoint
     // marks 0.05% on the CDF, the right 0.95%.
     const logHigh = math.log(high)

--- a/src/lib/guesstimator/samplers/DistributionNormal.js
+++ b/src/lib/guesstimator/samplers/DistributionNormal.js
@@ -2,7 +2,7 @@ import math from 'mathjs'
 import {simulate} from './Simulator.js'
 
 export var Sampler = {
-  sample({high, low}, n) {
+  sample({params: [low, high]}, n) {
     // This assumes a centered 90% confidence interval, e.g. the left endpoint
     // marks 0.05% on the CDF, the right 0.95%.
     const mean = math.mean(high, low)

--- a/src/lib/guesstimator/samplers/DistributionPoint.js
+++ b/src/lib/guesstimator/samplers/DistributionPoint.js
@@ -1,5 +1,5 @@
 export var Sampler = {
-  sample(formatted) {
-    return Promise.resolve({values: [formatted.value]})
+  sample({params: [value]}) {
+    return Promise.resolve({values: [value]})
   }
 }

--- a/src/lib/guesstimator/samplers/DistributionUniform.js
+++ b/src/lib/guesstimator/samplers/DistributionUniform.js
@@ -1,7 +1,7 @@
 import {simulate} from './Simulator.js'
 
 export var Sampler = {
-  sample({low, high}, n) {
+  sample({params: [low, high]}, n) {
     return simulate(`uniform(${low},${high})`, [], n)
   }
 }


### PR DESCRIPTION
This also slightly tightens the user facing API, by enforcing full parametrized match at parse time (e.g. `[1, 20` no longer parses).