### PR TITLE
Added privacy icon to the calculator when the calculator is private. Closes 596.

### DIFF
--- a/src/components/calculators/calculator-space-selector.js
+++ b/src/components/calculators/calculator-space-selector.js
@@ -25,9 +25,9 @@ export const calculatorSpaceSelector = createSelector(
   calculatorSelector,
   (graph, calculator) => {
     if (!_.has(calculator, 'space_id')) { return {} }
-    const dSpace = e.space.toDSpace(calculator.space_id, graph)
+    const {metrics, is_private} = e.space.toDSpace(calculator.space_id, graph)
 
-    const findById = id => dSpace.metrics.find(m => _sameId(m.id, id))
+    const findById = id => metrics.find(m => _sameId(m.id, id))
 
     const inputs = calculator.input_ids.map(findById).filter(m => relationshipType(m.edges) === INPUT)
     const outputs = calculator.output_ids.map(findById).filter(m => relationshipType(m.edges) !== INPUT)
@@ -36,6 +36,7 @@ export const calculatorSpaceSelector = createSelector(
       calculator,
       inputs,
       outputs,
+      isPrivate: is_private,
     }
   }
 )

--- a/src/components/calculators/show.js
+++ b/src/components/calculators/show.js
@@ -101,7 +101,7 @@ export class CalculatorShow extends Component {
   render() {
     if (!this.props.calculator) { return false }
 
-    const {calculator: {content, title, space_id, share_image}, inputs, outputs} = this.props
+    const {calculator: {content, title, space_id, share_image}, inputs, outputs, isPrivate} = this.props
     const spaceUrl = Space.url({id: space_id})
     const calculatorUrl = Calculator.fullUrl(this.props.calculator)
 
@@ -116,6 +116,10 @@ export class CalculatorShow extends Component {
     const {FacebookShareButton, TwitterShareButton} = ShareButtons
     const FacebookIcon = generateShareIcon('facebook')
     const TwitterIcon = generateShareIcon('twitter')
+    let privacy_header = false
+    if (isPrivate) {
+      privacy_header = (<span className='privacy-icon'><Icon name='lock'/>Private</span>)
+    }
 
     return (
       <Container>
@@ -124,7 +128,14 @@ export class CalculatorShow extends Component {
           <div className='col-xs-0 col-md-2'/>
           <div className='col-xs-12 col-md-8'>
             <div className='calculator'>
-              <h1>{title}</h1>
+              <div className='title-bar'>
+                <div className='row'>
+                  <div className='col-xs-12'>
+                    <h1>{title}</h1>
+                    {privacy_header}
+                  </div>
+                </div>
+              </div>
               <div className='description'>
                 <ReactMarkdown source={content} />
               </div>

--- a/src/components/calculators/style.css
+++ b/src/components/calculators/style.css
@@ -23,8 +23,15 @@
   font-size: 1.6em;
   line-height: 1.2em;
 
-  h1 {
-    font-size: 1.5em;
+  .title-bar {
+    h1 {
+      font-size: 1.5em;
+      display: inline;
+    }
+
+    span.privacy-icon {
+      padding-left: 1em;
+    }
   }
 
   .description {


### PR DESCRIPTION
It only shows up for private calculators, not public ones, which I think is a good thing, as that information doesn't seem relevant on a public calculator designed to reach a lot of users.
![calculator privacy icon](https://cloud.githubusercontent.com/assets/470751/16854680/e7a0d7ca-49c6-11e6-8075-5a950bb61d33.png)
Happy to restyle to a different spec if desired.