### PR TITLE
Added an 'expanded view' to show all inputs expanded and all readable IDs. Closes 573.

### DIFF
--- a/src/components/metrics/card/MetricCardViewSection/index.js
+++ b/src/components/metrics/card/MetricCardViewSection/index.js
@@ -76,6 +76,7 @@ export default class MetricCardViewSection extends Component {
     const hasGuesstimateDescription = !_.isEmpty(guesstimate.description)
     const anotherFunctionSelected = ((metricClickMode === 'FUNCTION_INPUT_SELECT') && !inSelectedCell)
     const hasErrors = (errors.length > 0)
+    const shouldShowReadableId = metricCardView === 'expanded' || anotherFunctionSelected
 
     let className = `MetricCardViewSection ${metricCardView}`
     className += (hasErrors & !inSelectedCell) ? ' hasErrors' : ''
@@ -91,10 +92,10 @@ export default class MetricCardViewSection extends Component {
         }
 
         <div className='MetricTokenSection'>
-          {(hovered || anotherFunctionSelected || hasGuesstimateDescription) &&
+          {(hovered || shouldShowReadableId || hasGuesstimateDescription) &&
             <MetricToken
               readableId={metric.readableId}
-              anotherFunctionSelected={anotherFunctionSelected}
+              shouldShowReadableId={shouldShowReadableId}
               onOpenModal={onOpenModal}
               hasGuesstimateDescription={hasGuesstimateDescription}
             />

--- a/src/components/metrics/card/index.js
+++ b/src/components/metrics/card/index.js
@@ -234,6 +234,7 @@ export default class MetricCard extends Component {
     const {guesstimate} = metric
     const errors = this._errors()
     const shouldShowSensitivitySection = this._shouldShowSensitivitySection()
+    const shouldShowDistributionEditor = canvasState.metricCardView === 'expanded' || inSelectedCell
 
     return (
       <div className='metricCard--Container'
@@ -271,7 +272,7 @@ export default class MetricCard extends Component {
             onTab={this.props.onTab}
           />
 
-          {inSelectedCell &&
+          {shouldShowDistributionEditor &&
             <div className='section editing'>
               <DistributionEditor
                 guesstimate={metric.guesstimate}

--- a/src/components/metrics/card/token/index.js
+++ b/src/components/metrics/card/token/index.js
@@ -26,10 +26,10 @@ const MetricReasoningIcon = () => (
   </span>
 )
 
-export const MetricToken = ({anotherFunctionSelected, readableId, onOpenModal, hasGuesstimateDescription}) => (
+export const MetricToken = ({shouldShowReadableId, readableId, onOpenModal, hasGuesstimateDescription}) => (
   <div className='MetricToken'>
-    {anotherFunctionSelected && <MetricReadableId readableId={readableId} /> }
-    {!anotherFunctionSelected && <MetricExpandButton onOpenModal={onOpenModal}/> }
-    {!anotherFunctionSelected && hasGuesstimateDescription && <MetricReasoningIcon/> }
+    {shouldShowReadableId && <MetricReadableId readableId={readableId} /> }
+    {!shouldShowReadableId && <MetricExpandButton onOpenModal={onOpenModal}/> }
+    {!shouldShowReadableId && hasGuesstimateDescription && <MetricReasoningIcon/> }
   </div>
 )

--- a/src/components/spaces/show/canvasViewForm.js
+++ b/src/components/spaces/show/canvasViewForm.js
@@ -58,7 +58,8 @@ export default class CanvasViewForm extends Component {
     let metricCardViewOptions = [
       {name: 'normal', image: normalImage},
       {name: 'analysis', image: debuggingImage},
-      {name: 'scientific', image: scientificImage}
+      {name: 'scientific', image: scientificImage},
+      {name: 'expanded', image: debuggingImage},
     ]
 
     let arrowViewOptions = [

--- a/src/modules/canvas_state/prop_type.js
+++ b/src/modules/canvas_state/prop_type.js
@@ -10,7 +10,7 @@ export const metricCardView = PT.oneOf([
   'normal',
   'scientific',
   'analysis',
-  'display'
+  'expanded',
 ]).isRequired
 
 export const metricClickMode = PT.oneOf([


### PR DESCRIPTION
I'm leaving the image for this view mode up to you to add, Ozzie, as I presumed you would want to take that. If not, and you want me to take a stab at it, happy to, just let me know.
![expanded-view](https://cloud.githubusercontent.com/assets/470751/16883653/e5fcdb36-4a79-11e6-992e-33ce9449c307.png)
