### PR TITLE
Makes guesstimates be stored internally with an `expression` field, which generates a human readable input.

### DIFF
--- a/src/components/distributions/editor/index.js
+++ b/src/components/distributions/editor/index.js
@@ -11,7 +11,7 @@ import {changeMetricClickMode} from 'gModules/canvas_state/actions'
 
 import {Guesstimator} from 'lib/guesstimator/index'
 
-import {expressionFromInput} from 'gEngine/guesstimate'
+import {inputToExpression} from 'gEngine/guesstimate'
 
 import './style.css'
 
@@ -53,7 +53,7 @@ export default class Guesstimate extends Component{
   }
 
   changeInput(input) {
-    const expression = expressionFromInput(input, this.props.metricIdsMap)
+    const expression = inputToExpression(input, this.props.metricIdsMap)
     const guesstimateType = this._guesstimateType({input})
     this.changeGuesstimate({data: null, input: null, expression, guesstimateType}, true, false)
     if (guesstimateType === 'FUNCTION' && this.props.guesstimateType !== 'FUNCTION') {

--- a/src/components/distributions/editor/index.js
+++ b/src/components/distributions/editor/index.js
@@ -11,6 +11,8 @@ import {changeMetricClickMode} from 'gModules/canvas_state/actions'
 
 import {Guesstimator} from 'lib/guesstimator/index'
 
+import {expressionFromInput} from 'gEngine/guesstimate'
+
 import './style.css'
 
 @connect(null, dispatch => bindActionCreators({changeGuesstimate, runFormSimulations, changeMetricClickMode}, dispatch), null, {withRef: true})
@@ -51,8 +53,9 @@ export default class Guesstimate extends Component{
   }
 
   changeInput(input) {
+    const expression = expressionFromInput(input, this.props.metricIdsMap)
     const guesstimateType = this._guesstimateType({input})
-    this.changeGuesstimate({data: null, input, guesstimateType}, true, false)
+    this.changeGuesstimate({data: null, input: null, expression, guesstimateType}, true, false)
     if (guesstimateType === 'FUNCTION' && this.props.guesstimateType !== 'FUNCTION') {
       this._changeMetricClickMode('FUNCTION_INPUT_SELECT')
     }

--- a/src/components/metrics/card/index.js
+++ b/src/components/metrics/card/index.js
@@ -223,6 +223,7 @@ export default class MetricCard extends Component {
       connectDragSource,
       selectedMetric,
       forceFlowGridUpdate,
+      metricIdsMap,
     } = this.props
     const {guesstimate} = metric
     const shouldShowSensitivitySection = this._shouldShowSensitivitySection()
@@ -270,6 +271,7 @@ export default class MetricCard extends Component {
                 guesstimate={metric.guesstimate}
                 inputMetrics={metric.edges.inputMetrics}
                 metricId={metric.id}
+                metricIdsMap={metricIdsMap}
                 metricFocus={this.focus.bind(this)}
                 jumpSection={() => {this.refs.MetricCardViewSection.focusName()}}
                 onOpen={this.openModal.bind(this)}

--- a/src/components/spaces/canvas/index.js
+++ b/src/components/spaces/canvas/index.js
@@ -133,6 +133,11 @@ export default class Canvas extends Component{
     return _.isEmpty(metric.name) && _.isEmpty(input) && _.isEmpty(data)
   }
 
+  metricIdsMap() {
+    const metrics = _.get(this, 'props.denormalizedSpace.metrics') || []
+    return metrics.reduce((map, curr) => _.set(map, curr.readableId, curr.id), {})
+  }
+
   renderMetric(metric, selected) {
     const {location} = metric
     const hasSelected = selected && metric && (selected.id !== metric.id)
@@ -144,6 +149,7 @@ export default class Canvas extends Component{
         key={metric.id}
         location={location}
         metric={metric}
+        metricIdsMap={this.metricIdsMap()}
         selectedMetric={passSelected && selected}
       />
     )

--- a/src/components/spaces/denormalized-space-selector.js
+++ b/src/components/spaces/denormalized-space-selector.js
@@ -1,4 +1,4 @@
-import { createSelector } from 'reselect';
+import { createSelector } from 'reselect'
 import e from 'gEngine/engine'
 
 const NAME = "Denormalized Space Selector"
@@ -28,16 +28,14 @@ export const denormalizedSpaceSelector = createSelector(
   spaceIdSelector,
   canvasStateSelector,
   (graph, spaceId, canvasState) => {
-    let dSpace = e.space.toDSpace(spaceId, graph)
+    let denormalizedSpace = e.space.toDSpace(spaceId, graph)
 
-    if (dSpace) {
-      dSpace.canvasState = canvasState
-      dSpace.checkpointMetadata = checkpointMetadata(spaceId, graph.checkpoints)
+    if (denormalizedSpace) {
+      denormalizedSpace.canvasState = canvasState
+      denormalizedSpace.checkpointMetadata = checkpointMetadata(spaceId, graph.checkpoints)
     }
 
-    window.recorder.recordSelectorStop(NAME, {denormalizedSpace: dSpace})
-    return {
-      denormalizedSpace: dSpace
-    };
+    window.recorder.recordSelectorStop(NAME, {denormalizedSpace})
+    return { denormalizedSpace }
   }
-);
+)

--- a/src/lib/engine/guesstimate.js
+++ b/src/lib/engine/guesstimate.js
@@ -90,3 +90,7 @@ export function inputsFromExpressions(metrics) {
   const translateFn = ({expression}) => expression.replace(RegExp(reParts.join('|'), 'g'), match => idMap[match])
   return g => !_.isEmpty(g.input) || _.isEmpty(g.expression) ? g : {...g, input: translateFn(g)}
 }
+
+export function expressionFromInput(input, idMap) {
+  return input.replace(RegExp(Object.keys(idMap).join('|'), 'g'), match => `\$\{${idMap[match]}\}`)
+}

--- a/src/lib/engine/guesstimate.js
+++ b/src/lib/engine/guesstimate.js
@@ -12,7 +12,7 @@ export function equals(l, r) {
   )
 }
 
-export const attributes = ['metric', 'expression', 'guesstimateType', 'description', 'data']
+export const attributes = ['metric', 'expression', 'input', 'guesstimateType', 'description', 'data']
 
 export function sample(guesstimate: Guesstimate, dGraph: DGraph, n: number = 1) {
   const metric = guesstimate.metric

--- a/src/lib/engine/guesstimate.js
+++ b/src/lib/engine/guesstimate.js
@@ -12,7 +12,7 @@ export function equals(l, r) {
   )
 }
 
-export const attributes = ['metric', 'input', 'guesstimateType', 'description', 'data']
+export const attributes = ['metric', 'expression', 'guesstimateType', 'description', 'data']
 
 export function sample(guesstimate: Guesstimate, dGraph: DGraph, n: number = 1) {
   const metric = guesstimate.metric
@@ -81,4 +81,12 @@ function _inputMetricsWithValues(guesstimate: Guesstimate, dGraph: DGraph): Obje
     ))
   })
   return [inputs, _.uniq(errors)]
+}
+
+export function inputsFromExpressions(metrics) {
+  let idMap = {}, reParts = []
+  metrics.forEach( ({id, readableId}) => {reParts.push(`\\\$\\\{${id}\\\}`); idMap[`\$\{${id}\}`] = readableId} )
+
+  const translateFn = ({expression}) => expression.replace(RegExp(reParts.join('|'), 'g'), match => idMap[match])
+  return g => !_.isEmpty(g.input) || _.isEmpty(g.expression) ? g : {...g, input: translateFn(g)}
 }

--- a/src/lib/engine/space.js
+++ b/src/lib/engine/space.js
@@ -12,10 +12,11 @@ export function get(collection, id){
   return collection.find(i => (i.id === id))
 }
 
-export function subset(graph, spaceId){
+export function subset(graph, spaceId, withInputs = false){
   if (spaceId){
     const metrics = graph.metrics.filter(m => m.space === spaceId)
-    const guesstimates = _.flatten(metrics.map(m => _metric.guesstimates(m, graph)))
+    const rawGuesstimates = _.flatten(metrics.map(m => _metric.guesstimates(m, graph)))
+    const guesstimates = withInputs ? rawGuesstimates.map(_guesstimate.inputsFromExpressions(metrics)) : rawGuesstimates
     const simulations = _.flatten(guesstimates.map(g => _guesstimate.simulations(g, graph)))
     return { metrics, guesstimates, simulations }
   } else {
@@ -47,13 +48,15 @@ export function toDSpace(spaceId, graph) {
 
   dSpace.edges = _dGraph.dependencyMap(dSpace)
 
+  const withInputFn = _guesstimate.inputsFromExpressions(dSpace.metrics)
   dSpace.metrics = dSpace.metrics.map(s => {
     let edges = {}
     edges.inputs = dSpace.edges.filter(i => i.output === s.id).map(e => e.input)
     edges.outputs = dSpace.edges.filter(i => i.input === s.id).map(e => e.output)
     edges.inputMetrics = edges.inputs.map(i => dSpace.metrics.find(m => m.id === i))
-    return Object.assign({}, s, {edges})
+    return {...s, guesstimate: withInputFn(s.guesstimate), edges}
   })
+
   return dSpace
 }
 

--- a/src/lib/propagation/graph-propagation.js
+++ b/src/lib/propagation/graph-propagation.js
@@ -60,7 +60,7 @@ export class GraphPropagation {
 
   _graph(): Graph {
     const state = this.getState()
-    let subset = e.space.subset(e.graph.create(state), this.spaceId)
+    let subset = e.space.subset(e.graph.create(state), this.spaceId, true)
 
     return subset
   }

--- a/src/modules/spaces/actions.js
+++ b/src/modules/spaces/actions.js
@@ -14,7 +14,7 @@ import {rootUrl, setupGuesstimateApi} from 'servers/guesstimate-api/constants'
 
 import {captureApiError} from 'lib/errors/index'
 
-let sActions = actionCreatorsFor('spaces');
+let sActions = actionCreatorsFor('spaces')
 
 function api(state) {
   function getToken(state) {
@@ -24,13 +24,13 @@ function api(state) {
 }
 
 export function destroy(object) {
-  const id = object.id;
+  const id = object.id
   return (dispatch, getState) => {
 
     const navigateTo = !!object.organization_id ? e.organization.urlById(object.organization_id) : e.user.urlById(object.user_id)
     app.router.history.navigate(navigateTo)
 
-    dispatch(sActions.deleteStart({id}));
+    dispatch(sActions.deleteStart({id}))
 
     api(getState()).models.destroy({spaceId: id}, (err, value) => {
       if (err) {
@@ -105,7 +105,7 @@ export function create(organizationId, params={}) {
     }
 
     dispatch(changeActionState('CREATING'))
-    const action = sActions.createStart(object);
+    const action = sActions.createStart(object)
 
     api(getState()).models.create(object, (err, value) => {
       if (err) {
@@ -127,7 +127,7 @@ export function copy(spaceId) {
     dispatch(changeActionState('COPYING'))
 
     const cid = cuid()
-    const action = sActions.createStart({id:cid});
+    const action = sActions.createStart({id:cid})
 
     api(getState()).copies.create({spaceId}, (err, value) => {
       if (err) {
@@ -149,7 +149,7 @@ export function copy(spaceId) {
 }
 
 function getSpace(getState, spaceId) {
-  let {spaces, metrics, guesstimates} = getState();
+  let {spaces, metrics, guesstimates} = getState()
   return e.space.get(spaces, spaceId)
 }
 
@@ -192,9 +192,9 @@ export function update(spaceId, params={}) {
 //updates graph only
 export function updateGraph(spaceId, saveOnServer=true) {
   return (dispatch, getState) => {
-    let {spaces, metrics, guesstimates} = getState();
+    let {spaces, metrics, guesstimates} = getState()
     let space = e.space.get(spaces, spaceId)
-    space = e.space.withGraph(space, {metrics, guesstimates});
+    space = e.space.withGraph(space, {metrics, guesstimates})
     space.graph = _.omit(space.graph, 'simulations')
     const updates = {graph: space.graph}
 


### PR DESCRIPTION
Metrics are referenced by `id` within the `expression` field, not `readableId`. The translation to & from human readable `input` form takes place around the user interactions with the Guesstimate and prior to simulation. 

Must go in (and be deployed) after https://github.com/getguesstimate/guesstimate-server/pull/147