### PR TITLE
The new fact form should reset properly after fact creation.

### DIFF
--- a/src/components/organizations/show/facts/facts.js
+++ b/src/components/organizations/show/facts/facts.js
@@ -8,7 +8,7 @@ import {getVar} from 'gEngine/facts'
 export class FactBookTab extends Component {
   state = {
     editingFactId: null,
-    factsAdded: 0,
+    newFactKey: 0,
   }
 
   componentWillUpdate(newProps) {
@@ -19,7 +19,7 @@ export class FactBookTab extends Component {
 
   onAddFact(fact) {
     this.props.onAddFact(fact)
-    this.setState({factsAdded: this.state.factsAdded + 1})
+    this.setState({newFactKey: this.state.newFactKey + 1})
   }
 
   renderFactShow(fact) {
@@ -35,7 +35,7 @@ export class FactBookTab extends Component {
   renderFactForm(fact = null) {
     const {facts, onEditFact} = this.props
     let props = {
-      key: !!fact ? fact.id : this.state.factsAdded.toString(),
+      key: !!fact ? fact.id : this.state.newFactKey.toString(),
       existingVariableNames: facts.map(getVar).filter(v => v !== getVar(fact)),
       buttonText: !!fact ? 'Save' : 'Create',
       onSubmit: (!!fact ? onEditFact : this.onAddFact.bind(this)),

--- a/src/components/organizations/show/facts/facts.js
+++ b/src/components/organizations/show/facts/facts.js
@@ -8,12 +8,18 @@ import {getVar} from 'gEngine/facts'
 export class FactBookTab extends Component {
   state = {
     editingFactId: null,
+    factsAdded: 0,
   }
 
   componentWillUpdate(newProps) {
     if (!!this.state.editingFactId && !_.isEqual(this.props.facts, newProps.facts)) {
       this.setState({editingFactId: null})
     }
+  }
+
+  onAddFact(fact) {
+    this.props.onAddFact(fact)
+    this.setState({factsAdded: this.state.factsAdded + 1})
   }
 
   renderFactShow(fact) {
@@ -27,12 +33,12 @@ export class FactBookTab extends Component {
   }
 
   renderFactForm(fact = null) {
-    const {facts, onAddFact, onEditFact} = this.props
+    const {facts, onEditFact} = this.props
     let props = {
-      key: !!fact ? fact.id : 'new',
+      key: !!fact ? fact.id : this.state.factsAdded.toString(),
       existingVariableNames: facts.map(getVar).filter(v => v !== getVar(fact)),
       buttonText: !!fact ? 'Save' : 'Create',
-      onSubmit: (!!fact ? onEditFact : onAddFact),
+      onSubmit: (!!fact ? onEditFact : this.onAddFact.bind(this)),
     }
     if (!!fact) {props.startingFact = fact}
     return (<FactForm {...props}/>)


### PR DESCRIPTION
Ostensibly this should chain to the actual API call via a promise or something, but this is sufficient for now. Alternatively, if the storage as state bothers you it can be made a class variable that's not part of state instead, that would also work.