### PR TITLE
Reverting the selector search algorithm to a direct search.

### DIFF
--- a/src/lib/engine/facts.js
+++ b/src/lib/engine/facts.js
@@ -35,7 +35,6 @@ export const HANDLE_REGEX = /(?:@\w+(?:\.\w+)?|#\w+)/g
 export const getVar = f => _.get(f, 'variable_name') || ''
 export const byVariableName = name => f => getVar(f) === name
 const namedLike = partial => f => getVar(f).startsWith(partial)
-const variableNameIntersection = (f1, f2) => _.intersection(f1.split(''), f2.split('')).join('')
 
 export function withSortedValues(rawFact) {
   let fact = Object.assign({}, rawFact)
@@ -51,7 +50,7 @@ export function selectorSearch(selector, facts) {
   const matches = possibleFacts.filter(namedLike(partial))
   if (_.isEmpty(matches)) { return {partial, suggestion: ''} }
 
-  const suggestion = _.map(matches, getVar).reduce(variableNameIntersection)
+  const suggestion = getVar(matches[0])
   return {partial, suggestion}
 }
 


### PR DESCRIPTION
The shortest shared prefix approach was hurting the UX, and not working properly, so I just got rid of it for now. Won't much matter if we go to a dropdown soon anyways.