### PR TITLE
Use the https clone URL rather than the ssh URL.

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ API_ENV=production (as opposed to development) means that it will use the produc
 
 First, make sure that git and node are installed.
 
-``git clone git@github.com:getguesstimate/guesstimate-app.git``
+``git clone https://github.com/getguesstimate/guesstimate-app.git``
 
 ``cd guesstimate-app``
 


### PR DESCRIPTION
HTTPs cloning works for everyone whether or not they have an ssh key set up.