### PR TITLE
There are only 2 's's in 'guesstimate'

### DIFF
--- a/src/components/metrics/card/updated.js
+++ b/src/components/metrics/card/updated.js
@@ -12,6 +12,6 @@ export function hasMetricUpdated(oldProps, newProps) {
     (!!oldProps.metric.simulation && (oldProps.metric.simulation.propagationId !== newProps.metric.simulation.propagationId)) ||
     !!oldProps.metric.guesstimate !== !!newProps.metric.guesstimate ||
     oldProps.metric.guesstimate.description !== newProps.metric.guesstimate.description ||
-    oldProps.metric.guesstimate.guessstimateType !== newProps.metric.guesstimate.guesstimateType
+    oldProps.metric.guesstimate.guesstimateType !== newProps.metric.guesstimate.guesstimateType
   )
 }


### PR DESCRIPTION
This was causing all metric cards to update on any change.