### PR TITLE
Do not allow adjusted interval to break

### DIFF
--- a/src/components/distributions/summary/index.js
+++ b/src/components/distributions/summary/index.js
@@ -28,12 +28,18 @@ const DistributionDisplay = ({mean, range: [low, high]}) => (
 
 // TODO(matthew): Ostensibly I'd like to handle the defensivity upstream, but this is a good quick fix for the problem
 // exposed to customers presently.
-export const DistributionSummary = ({length, mean, adjustedConfidenceInterval}) => (
-  <div className="DistributionSummary">
-    {length === 1 || _.some(adjustedConfidenceInterval, e => !_.isFinite(e)) ?
-      <PointDisplay value={mean}/> 
-        :
-      <DistributionDisplay mean={mean} range={adjustedConfidenceInterval}/>
-    }
-  </div>
-)
+export const DistributionSummary = ({length, mean, adjustedConfidenceInterval}) => {
+  console.log(length, mean, adjustedConfidenceInterval)
+  const hasLength = length === 1 ||
+    adjustedConfidenceInterval[0] === adjustedConfidenceInterval[1] ||
+    _.some(adjustedConfidenceInterval, e => !_.isFinite(e))
+  return (
+    <div className="DistributionSummary">
+      {hasLength ?
+        <PointDisplay value={mean}/>
+          :
+        <DistributionDisplay mean={mean} range={adjustedConfidenceInterval}/>
+      }
+    </div>
+  )
+}

--- a/src/lib/engine/simulation.js
+++ b/src/lib/engine/simulation.js
@@ -32,8 +32,8 @@ export function addStats(simulation){
     50: percentile(sortedValues, length, 50),
     95: percentile(sortedValues, length, 95),
   }
-  const adjustedLow = percentile(sortedValues, meanIndex, 10)
-  const adjustedHigh = percentile(sortedValues.slice(meanIndex), length - meanIndex, 90)
+  const adjustedLow = meanIndex === -1 ? sortedValues[0] : percentile(sortedValues, meanIndex, 10)
+  const adjustedHigh = meanIndex === -1 ? sortedValues[0] : percentile(sortedValues.slice(meanIndex), length - meanIndex, 90)
 
   const stats = {
     mean,


### PR DESCRIPTION
The big issue was that if an array had all of one element, ``meanIndex`` would be -1, which would really mess up the inputs of the percentile functions in adjustedLow and adjustedHigh.