### PR TITLE
Added missing parameters into the facts upon fetch if they are returned with incomplete stats.

### DIFF
--- a/src/lib/engine/facts.js
+++ b/src/lib/engine/facts.js
@@ -41,9 +41,16 @@ export const getVar = f => _.get(f, 'variable_name') || ''
 export const byVariableName = name => f => getVar(f) === name
 const namedLike = partial => f => getVar(f).startsWith(partial)
 
-export function withSortedValues(rawFact) {
-  let fact = Object.assign({}, rawFact)
+export function withMissingStats(rawFact) {
+  let fact = _utils.mutableCopy(rawFact)
   _.set(fact, 'simulation.sample.sortedValues', sortDescending(_.get(fact, 'simulation.sample.values')))
+
+  const length = _.get(fact, 'simulation.stats.length')
+  const needsACI = _.isFinite(length) && length > 1
+  const ACIlength = _.get('simulation.stats.adjustedConfidenceInterval.length')
+  const hasACI = _.isFinite(ACIlength) && ACIlength === 2
+  if (needsACI && !hasACI) { _.set(fact, 'simulation.stats.adjustedConfidenceInterval', [null, null]) }
+
   return fact
 }
 

--- a/src/modules/facts/actions.js
+++ b/src/modules/facts/actions.js
@@ -1,6 +1,6 @@
 import {editFact} from 'gModules/organizations/actions'
 
-import {selectorSearch, withSortedValues} from 'gEngine/facts'
+import {selectorSearch, withMissingStats} from 'gEngine/facts'
 import * as _collections from 'gEngine/collections'
 import {organizationIdFromFactReadableId} from 'gEngine/organization'
 import {addStats} from 'gEngine/simulation'
@@ -25,11 +25,11 @@ export function loadByOrg(facts) {
 }
 
 export function addToOrg(organizationVariableName, fact) {
-  return {type: 'ADD_FACT_TO_ORG', organizationVariableName, fact: withSortedValues(fact)}
+  return {type: 'ADD_FACT_TO_ORG', organizationVariableName, fact: withMissingStats(fact)}
 }
 
 export function updateWithinOrg(organizationVariableName, fact) {
-  return {type: 'UPDATE_FACT_WITHIN_ORG', organizationVariableName, fact: withSortedValues(fact)}
+  return {type: 'UPDATE_FACT_WITHIN_ORG', organizationVariableName, fact: withMissingStats(fact)}
 }
 
 export function deleteFromOrg(organizationVariableName, {id}) {

--- a/src/modules/organizations/actions.js
+++ b/src/modules/organizations/actions.js
@@ -10,7 +10,7 @@ import * as factActions from 'gModules/facts/actions'
 import * as spaceActions from 'gModules/spaces/actions'
 
 import {organizationReadableId} from 'gEngine/organization'
-import {withSortedValues} from 'gEngine/facts'
+import {withMissingStats} from 'gEngine/facts'
 
 import {captureApiError} from 'lib/errors/index'
 
@@ -40,7 +40,7 @@ export function fetchById(organizationId) {
   }
 }
 
-const toContainerFact = o => _.isEmpty(o.facts) ? {} : {variable_name: organizationReadableId(o), children: o.facts.map(withSortedValues)}
+const toContainerFact = o => _.isEmpty(o.facts) ? {} : {variable_name: organizationReadableId(o), children: o.facts.map(withMissingStats)}
 
 export function fetchSuccess(organizations) {
   return (dispatch) => {


### PR DESCRIPTION
In particular, we may need to add a pseudo-empty ACI to the facts upon return as Rails Strong Params does not recognize  as a permitted scalar type within arrays.