### PR TITLE
Minor UI improvements to fact graph functionality

### DIFF
--- a/src/components/facts/list/style.css
+++ b/src/components/facts/list/style.css
@@ -40,6 +40,7 @@ $blue-a1: #4A6A88;
   float: left;
   width: 100%;
   margin: .1em 0;
+  display: flex;
 
   &:hover {
     border-color: #d9dee2;
@@ -49,6 +50,7 @@ $blue-a1: #4A6A88;
     margin: .1em .6em;
 
     .Fact {
+      flex: 1;
       flex-direction: column-reverse;
     }
   }
@@ -143,6 +145,7 @@ $blue-a1: #4A6A88;
   flex: 6;
   margin-top: .05em;
   padding: .3em .4em 0;
+  word-wrap: break-word;
 
   .fact-name {
     font-size: 1.2em;

--- a/src/components/spaces/show/header.js
+++ b/src/components/spaces/show/header.js
@@ -117,7 +117,6 @@ export class SpaceHeader extends Component {
                 </div>
               </ShareableLinkOption>
             }
-            {ownerIsOrg && <a className='ui image label' href={`${ownerUrl}/fact-graph`}><Icon name='expand'/></a>}
             {editableByMe &&
               <PrivacyToggle
                 editableByMe={editableByMe}

--- a/src/components/spaces/show/style.css
+++ b/src/components/spaces/show/style.css
@@ -196,6 +196,7 @@
   margin-top: 0.5em;
   margin-bottom: 1em;
   font-size: 1.1em;
+  word-wrap: break-word;
 }
 
 .SpaceSidebar .SpaceSidebar-body .ClickToEdit {


### PR DESCRIPTION
- Added 'break-word' to fact names and space sidebar areas, so they couldn't overflow.
- Added display: flex to facts, so they would be the same height as other elements in row.
- Removed 'expand' button.