### PR TITLE
Use the same DAG library (mostly) across the two DAG use cases.

### DIFF
--- a/src/components/calculators/show/CalculatorShow.js
+++ b/src/components/calculators/show/CalculatorShow.js
@@ -7,10 +7,10 @@ import Icon from 'react-fa'
 
 import {Input} from './input'
 import {Output} from './output'
+import {Button} from 'gComponents/utility/buttons/button.js'
 
 import {deleteSimulations, runSimulations} from 'gModules/simulations/actions'
 import {changeGuesstimate} from 'gModules/guesstimates/actions'
-import {Button} from 'gComponents/utility/buttons/button.js'
 
 import * as _simulation from 'gEngine/simulation'
 
@@ -28,7 +28,7 @@ export class CalculatorShow extends Component {
   }
 
   componentWillReceiveProps(nextProps) {
-    if (this.state.resultComputing && this.allOutputsHaveStats()) {
+    if (this.state.resultComputing && this.allOutputsHaveStats(nextProps)) {
       this.setState({resultComputing: false})
       this.showResult()
     }
@@ -91,8 +91,8 @@ export class CalculatorShow extends Component {
     return _.every(inputComponents, i => !!i && i.hasValidContent())
   }
 
-  allOutputsHaveStats() {
-    return this.props.outputs.map(o => !!o && _.has(o, 'simulation.stats')).reduce((x,y) => x && y, true)
+  allOutputsHaveStats({outputs} = this.props) {
+    return outputs.map(o => !!o && _.has(o, 'simulation.stats')).reduce((x,y) => x && y, true)
   }
 
   showResult() {

--- a/src/components/calculators/style.css
+++ b/src/components/calculators/style.css
@@ -19,6 +19,10 @@
 
 .calculator {
   .title-bar {
+    float: left;
+    width: 100%;
+    margin-bottom: 1em;
+
     .action-section{
       padding-top: .4em;
     }

--- a/src/components/distributions/summary/index.js
+++ b/src/components/distributions/summary/index.js
@@ -28,10 +28,10 @@ const DistributionDisplay = ({mean, range: [low, high]}) => (
 
 // TODO(matthew): Ostensibly I'd like to handle the defensivity upstream, but this is a good quick fix for the problem
 // exposed to customers presently.
-export const DistributionSummary = ({length, mean, adjustedConfidenceInterval}) => (
+export const DistributionSummary = ({length, mean, adjustedConfidenceInterval, precision=6}) => (
   <div className="DistributionSummary">
     {length === 1 || _.some(adjustedConfidenceInterval, e => !_.isFinite(e)) ?
-      <PointDisplay value={mean}/> 
+      <PointDisplay value={mean} precision={precision}/>
         :
       <DistributionDisplay mean={mean} range={adjustedConfidenceInterval}/>
     }

--- a/src/components/facts/list/item.js
+++ b/src/components/facts/list/item.js
@@ -23,6 +23,7 @@ export const FactItem = ({fact, onEdit, isExportedFromSelectedSpace, size}) => {
                   length={length(fact)}
                   mean={mean(fact)}
                   adjustedConfidenceInterval={adjustedConfidenceInterval(fact)}
+                  precision={4}
                 />
               </div>
               <div className='histogram'>

--- a/src/components/facts/list/list.js
+++ b/src/components/facts/list/list.js
@@ -81,11 +81,11 @@ export class FactList extends Component {
 
     return (
       <div>
-        {!!exported.length && <h3> Model Outputs </h3>}
+        {!!exported.length && <h3> Model Output Metrics </h3>}
         {this.renderFactSublist(exported)}
-        {!!imported.length && <h3> Model Inputs </h3>}
+        {!!imported.length && <h3> Model Input Metrics </h3>}
         {this.renderFactSublist(imported)}
-        {!!filteredFacts.length && <h3> Other Facts </h3>}
+        {!!filteredFacts.length && <h3> Other Library Metrics </h3>}
         {this.renderFactSublist(filteredFacts)}
       </div>
     )
@@ -115,6 +115,6 @@ export class FactList extends Component {
 const NewButton = ({onClick}) => (
   <div className='NewFactButton' onClick={onClick}>
     <Icon name='plus'/>
-    New Fact
+    New Metric
   </div>
 )

--- a/src/components/organizations/new/form.js
+++ b/src/components/organizations/new/form.js
@@ -23,7 +23,7 @@ export const PlanList = ({onSelect, plan}) => (
     </PlanElement>
     <PlanElement onClick={() => {onSelect('PREMIUM')}} isSelected={plan === 'PREMIUM'}>
       Unlimited private models. $12/month per user.
-      <div className='free-trial'>Free 14-day trial, no credit card needed.</div>
+      <div className='free-trial'>Free 30-day trial, no credit card needed.</div>
     </PlanElement>
   </div>
 )

--- a/src/components/organizations/show/index.js
+++ b/src/components/organizations/show/index.js
@@ -120,8 +120,8 @@ export default class OrganizationShow extends Component{
     if (hasPrivateAccess) {
       tabs = [
         {name: 'Models', key: MODEL_TAB},
-        {name: 'Facts', key: FACT_BOOK_TAB},
-        {name: 'Fact Graph', key: FACT_GRAPH_TAB},
+        {name: 'Metric Library', key: FACT_BOOK_TAB},
+        {name: 'Metric Graph', key: FACT_GRAPH_TAB},
         {name: 'Members', key: MEMBERS_TAB}
       ]
     }

--- a/src/components/spaces/show/Toolbar/index.js
+++ b/src/components/spaces/show/Toolbar/index.js
@@ -143,7 +143,7 @@ export class SpaceToolbar extends Component {
             <ReactTooltip {...ReactTooltipParams} id='undo-button'>Undo (ctrl-z)</ReactTooltip>
             <ReactTooltip {...ReactTooltipParams} id='redo-button'>Redo (ctrl-shift-z)</ReactTooltip>
             <ReactTooltip {...ReactTooltipParams} id='calculator'>Calculators</ReactTooltip>
-            <ReactTooltip {...ReactTooltipParams} id='facts'>Facts</ReactTooltip>
+            <ReactTooltip {...ReactTooltipParams} id='facts'>Metric Library</ReactTooltip>
 
             {isLoggedIn &&
               <DropDown

--- a/src/components/spaces/show/index.js
+++ b/src/components/spaces/show/index.js
@@ -14,7 +14,7 @@ import {EditCalculatorForm} from 'gComponents/calculators/edit'
 import {CalculatorCompressedShow} from 'gComponents/calculators/show/CalculatorCompressedShow'
 import {ButtonCloseText} from 'gComponents/utility/buttons/close'
 import {ButtonEditText, ButtonDeleteText, ButtonExpandText} from 'gComponents/utility/buttons/button'
-import {FactListContainer} from 'gComponents/facts/list/container.js'
+import {FactListContainer} from 'gComponents/facts/list/container'
 import {Tutorial} from './Tutorial/index'
 
 import {denormalizedSpaceSelector} from '../denormalized-space-selector'

--- a/src/components/spaces/show/index.js
+++ b/src/components/spaces/show/index.js
@@ -75,7 +75,7 @@ const CalculatorFormHeader = ({isNew, onClose}) => (
 const FactSidebarHeader = ({onClose, organizationId}) => (
   <div className='row'>
     <div className='col-xs-6'>
-      <h2> Private Facts </h2>
+      <h2> Metric Library </h2>
     </div>
     <div className='col-xs-6'>
       <ButtonExpandText onClick={navigateFn(`/organizations/${organizationId}/facts`)}/>

--- a/src/components/spaces/show/style.css
+++ b/src/components/spaces/show/style.css
@@ -134,6 +134,7 @@
   z-index: 2;
   margin: 24px 15px 14px 14px;
   overflow: auto;
+  background: rgba(223,225,228,0.1);
 
   .closeSidebar {
     float: right;

--- a/src/lib/DAG/DAG-test.js
+++ b/src/lib/DAG/DAG-test.js
@@ -55,7 +55,7 @@ describe('DAG library', () => {
           id: null,
           isCycle: true,
           inputs: ['K'],
-          dependants: [],
+          outputs: [],
           nodes: [
             {id: 'A', inputs: ['G']},
             {id: 'B', inputs: ['A']},
@@ -69,7 +69,7 @@ describe('DAG library', () => {
           id: null,
           isCycle: true,
           inputs: [],
-          dependants: [],
+          outputs: [],
           nodes: [
             {id: 'H', inputs: ['K']},
             {id: 'I', inputs: ['H']},

--- a/src/lib/DAG/DAG.js
+++ b/src/lib/DAG/DAG.js
@@ -51,7 +51,7 @@ export function toCyclePseudoNode(nodes) {
     id: null,
     isCycle: true,
     inputs: _.uniq(_.flatten(nodes.map(n => orArr(n.inputs).filter(notIn(containedIds))))),
-    dependants: _.uniq(_.flatten(nodes.map(n => orArr(n.dependants).filter(notIn(containedIds))))),
+    outputs: _.uniq(_.flatten(nodes.map(n => orArr(n.outputs).filter(notIn(containedIds))))),
     nodes,
   }
 }


### PR DESCRIPTION
Also rename parents -> inputs and children/dependants -> outputs across both DAG libs for consistency.