### PR TITLE
Addressing console warning on new org page. Closes #705.

### DIFF
--- a/src/components/organizations/new/form.js
+++ b/src/components/organizations/new/form.js
@@ -8,7 +8,7 @@ import {create} from 'gModules/organizations/actions'
 export const PlanElement = ({onClick, isSelected, children}) => (
   <div className={`PlanElement ${isSelected && 'selected'}`} onClick={onClick}>
     <div className='radio-section'>
-      <input type='radio' checked={isSelected}/>
+      <input type='radio' checked={isSelected} readOnly={true}/>
     </div>
     <div className='content-section'>
       {children}


### PR DESCRIPTION
The radio buttons didn't have onChange handlers, so React didn't like that they had 'checked' props without 'readonly' set.