### PR TITLE
Refining the rename menu for unnamed models. Closes #223.

### DIFF
--- a/src/components/spaces/show/spaceName.js
+++ b/src/components/spaces/show/spaceName.js
@@ -3,10 +3,11 @@ import React, {Component} from 'react'
 import DropDown from 'gComponents/utility/drop-down/index.js'
 
 export class SpaceName extends Component {
+  focusForm() { this.refs.name.focus() }
+
   onSave() {
+    this.props.onSave(this.refs.name.value)
     this.refs.DropDown._close()
-    const name = this.refs.name.value
-    this.props.onSave(name)
   }
 
   render () {
@@ -18,24 +19,31 @@ export class SpaceName extends Component {
       <span>
         {editableByMe &&
           <DropDown
-            headerText={'Rename Model'}
+            headerText={hasName ? 'Rename Model' : 'Name Model'}
             openLink={<h1 className={className}> {showName} </h1>}
             position='right'
             hasPadding={true}
             width='wide'
+            onOpen={this.focusForm.bind(this)}
             ref='DropDown'
           >
-          <div className='ui form'>
-            <textarea
-              defaultValue={name}
-              type='text'
-              rows='2'
-              ref='name'
-            />
-            <div className='ui button primary large' onClick={this.onSave.bind(this)}>
-                Rename
+            <div className='ui form'>
+              <textarea
+                defaultValue={name}
+                type='text'
+                rows='2'
+                ref='name'
+              />
+              {!hasName &&
+                <p>
+                  What are you trying to estimate? Be specific, so others can understand. Example: 'The time it will take
+                  George to walk home.'
+                </p>
+              }
+              <div className='ui button primary large' onClick={this.onSave.bind(this)}>
+                {hasName ? 'Rename Model' : 'Name Model'}
+              </div>
             </div>
-          </div>
           </DropDown>
         }
         {!editableByMe &&

--- a/src/components/spaces/show/style.css
+++ b/src/components/spaces/show/style.css
@@ -103,6 +103,11 @@
 .hero-unit .header-name {
   max-width: 60%;
   float: left;
+  p {
+    padding-top: 0;
+    margin-top: 0;
+    color: grey;
+  }
 }
 
 @media only screen and (max-width: 767px) {

--- a/src/components/utility/drop-down/index.js
+++ b/src/components/utility/drop-down/index.js
@@ -15,7 +15,7 @@ export default class DropDown extends Component {
   }
 
   constructor(props) {
-    super(props);
+    super(props)
 
     this.state = {
       isOpen: props.isOpen || false
@@ -31,18 +31,21 @@ export default class DropDown extends Component {
   }
 
   componentWillUnmount() {
-    document.removeEventListener('click', this.handleDocumentClick, false);
+    document.removeEventListener('click', this.handleDocumentClick, false)
+  }
+
+  componentDidUpdate(prevProps, prevState) {
+    if (!prevState.isOpen && this.state.isOpen && !!this.props.onOpen) { this.props.onOpen() }
   }
 
   _open() {
     this.setState({isOpen: true})
-    document.addEventListener('click', this.handleDocumentClick, false);
-    if (this.props.onOpen) {this.props.onOpen()}
+    document.addEventListener('click', this.handleDocumentClick, false)
   }
 
   _close() {
     this.setState({isOpen: false})
-    document.removeEventListener('click', this.handleDocumentClick, false);
+    document.removeEventListener('click', this.handleDocumentClick, false)
     if (this.props.onClose) {this.props.onClose()}
   }
 


### PR DESCRIPTION
Refines the 'rename' menu for unnamed models, according to the spec laid out in #223.

![new name form](https://cloud.githubusercontent.com/assets/470751/20370951/57ada500-ac16-11e6-9458-92736f504eef.png)

It is staged on matthew.getguesstimate.com. Let me know if you'd like any style changes.