### PR TITLE
Handle unverified-email logins and smooth account linking

### DIFF
--- a/src/components/pages/AuthRedirect.tsx
+++ b/src/components/pages/AuthRedirect.tsx
@@ -12,6 +12,16 @@ const content = `
 ## You are being redirected.
 `;
 
+const verifyEmailContent = `
+# Please confirm your email
+
+## We sent you a confirmation link.
+
+Check your inbox and click the link to verify your email address, then
+sign in again. If you signed up with the same email as a Google or GitHub
+login, your accounts will be linked automatically once confirmed.
+`;
+
 export const AuthRedirect: FC = () => {
   const router = useRouter();
 
@@ -22,6 +32,10 @@ export const AuthRedirect: FC = () => {
       router.push(user.urlById(me.profile.id));
     }
   }, [me, router]);
+
+  if (me.tag === "SIGNED_IN_NO_PROFILE") {
+    return <PageBase content={verifyEmailContent} />;
+  }
 
   return <PageBase content={content} />;
 };

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -5,3 +5,15 @@ export async function signIn() {
     callbackUrl: "/auth-redirect",
   });
 }
+
+// Re-authenticate without showing Auth0's login screen. Used right after email
+// verification: the Auth0 session is already alive, so `prompt=none` lets us
+// silently get a fresh token (which re-runs account linking) with no extra
+// click. The third arg is forwarded as authorization query params.
+export async function signInSilently() {
+  await nextAuthSignIn(
+    "auth0",
+    { callbackUrl: "/auth-redirect" },
+    { prompt: "none" }
+  );
+}

--- a/src/modules/me/actions.ts
+++ b/src/modules/me/actions.ts
@@ -37,3 +37,11 @@ export function guesstimateMeLoaded(profile: MeProfile): AppThunk {
     dispatch(meSlice.actions.setProfile({ profile }));
   };
 }
+
+// called when the user is authenticated but the backend has no matching
+// account (e.g. unconfirmed email signup that was never provisioned).
+export function guesstimateMeNoProfile(): AppThunk {
+  return (dispatch) => {
+    dispatch(meSlice.actions.setNoProfile());
+  };
+}

--- a/src/modules/me/slice.ts
+++ b/src/modules/me/slice.ts
@@ -36,6 +36,14 @@ type MeState =
       tag: "SIGNED_IN";
       session: Session;
       profile: MeProfile;
+    }
+  | {
+      // Authenticated with Auth0, but the backend has no matching user.
+      // Happens e.g. when someone signs up with email/password and hasn't
+      // confirmed their email yet, so the account was never provisioned.
+      tag: "SIGNED_IN_NO_PROFILE";
+      session: Session;
+      profile: undefined;
     };
 
 export const meSlice = createSlice({
@@ -70,7 +78,17 @@ export const meSlice = createSlice({
         profile: action.payload.profile,
       };
     },
-    destroy() {
+    setNoProfile(state) {
+      if (state.tag === "SIGNED_OUT") {
+        return state;
+      }
+      return {
+        tag: "SIGNED_IN_NO_PROFILE",
+        session: state.session,
+        profile: undefined,
+      };
+    },
+    destroy(): MeState {
       return { tag: "SIGNED_OUT", profile: undefined, session: null };
     },
   },

--- a/src/modules/users/actions.ts
+++ b/src/modules/users/actions.ts
@@ -20,6 +20,13 @@ export function fetchMe(auth0_id: string): AppThunk {
     try {
       const data = await api(getState()).users.listWithAuth0Id(auth0_id);
       const me = data.items[0];
+      if (!me) {
+        // Authenticated, but the backend has no user for this identity.
+        // Usually an unconfirmed email signup that was never provisioned.
+        // Don't fake a signed-in profile — that crashes the UI.
+        dispatch(meActions.guesstimateMeNoProfile());
+        return;
+      }
       dispatch(meActions.guesstimateMeLoaded(me as any)); // FIXME - casting lies
       dispatch(fetchById(me.id));
     } catch (err) {

--- a/src/pages/verify-complete.tsx
+++ b/src/pages/verify-complete.tsx
@@ -1,0 +1,35 @@
+import { NextPage } from "next";
+import { useEffect } from "react";
+
+import { signInSilently } from "~/lib/auth";
+import { AppLayout } from "~/components/layout";
+import { PageBase } from "~/components/utility/PageBase";
+
+const content = `
+# Email confirmed
+
+## Signing you in…
+`;
+
+// Target of the Auth0 "verify email" link (the email template's Redirect To).
+// After the email is confirmed we must start a *fresh* login so Auth0 re-runs
+// the account-linking Action and issues a token under the primary account.
+// Just landing on a page reuses the old (pre-verification) session and would
+// leave linked accounts unresolved.
+const VerifyCompletePage: NextPage = () => {
+  if (typeof window === "undefined") {
+    return null;
+  }
+
+  useEffect(() => {
+    signInSilently();
+  }, []);
+
+  return (
+    <AppLayout>
+      <PageBase content={content} />
+    </AppLayout>
+  );
+};
+
+export default VerifyCompletePage;


### PR DESCRIPTION
## Problem

Logging in via Auth0 when the backend has **no matching user** crashed the app: the UI set a signed-in state with an undefined profile, and `HeaderRightMenu` blew up reading `profile.id` (`Cannot read properties of undefined (reading 'id')`).

This happens for email/password signups whose email isn't confirmed yet — the account is never provisioned, and on verification the linking Action only runs at login, so the user lands with no backend profile.

## Changes

- **No crash:** add a `SIGNED_IN_NO_PROFILE` me-state. `fetchMe` dispatches it when the backend returns no user, instead of faking a profile.
- **Clear message:** `AuthRedirect` shows a "please confirm your email" screen for that state.
- **Smooth verify → link:** add a `verify-complete` page (target of the Auth0 verify-email link) that silently re-authenticates (`prompt=none`). Once the email is confirmed, the account-linking Action runs and the user lands signed in with all identities (email + Google + GitHub) merged into one account — no extra click.

## Deploy steps (Auth0, prod)

- Set the prod `verify_email` email template **Redirect To** → `https://www.getguesstimate.com/verify-complete`.

(The post-login linking Action and the Authentor `update:users` scope were already configured in prod.)

## Testing

Verified end-to-end in local dev against the dev Auth0 tenant: email signup → confirm email → silent re-auth → single account with email+github+google linked, one backend user row, no crash and no button.

🤖 Generated with [Claude Code](https://claude.com/claude-code)