### PR TITLE
Migrate Chargebee checkout from v1 to v2

### DIFF
--- a/src/components/subscriptions/FirstSubscription/NewOrder.tsx
+++ b/src/components/subscriptions/FirstSubscription/NewOrder.tsx
@@ -1,16 +1,4 @@
-import { useEffect, useRef } from "react";
-
-const newStyle = (height: number, hidden: boolean) => {
-  let style = `
-    width: 400px;
-    border: none;
-    border-radius: 5px;
-    overflow: hidden;
-  `;
-  style += "height:" + (height + 10) + "px;";
-  hidden && (style += "display:none;");
-  return style;
-};
+import { useEffect } from "react";
 
 export const NewOrder: React.FC<{
   page: string;
@@ -18,28 +6,26 @@ export const NewOrder: React.FC<{
   onSuccess(): void;
   onCancel(): void;
 }> = ({ page, name, onSuccess, onCancel }) => {
-  const ref = useRef<HTMLDivElement | null>(null);
-
   useEffect(() => {
     let timer: number | undefined;
+    let opened = false;
     const fn = () => {
-      // wait for ChargeBee to load
-      if (!window.ChargeBee) {
+      // wait for Chargebee.js (v2) to load
+      if (!window.Chargebee) {
         timer = window.setTimeout(fn, 300);
         return;
       }
-      window.ChargeBee.embed(page, name).load({
-        addIframe(iframe) {
-          ref.current?.append(iframe);
-        },
-        onLoad(iframe, _width: number, height: number) {
-          iframe.setAttribute("style", newStyle(height, false));
-        },
-        onResize(iframe, _width: number, height: number) {
-          iframe.setAttribute("style", newStyle(height, false));
-        },
-        onSuccess,
-        onCancel,
+      let cbInstance: any;
+      try {
+        cbInstance = window.Chargebee.getInstance();
+      } catch {
+        cbInstance = window.Chargebee.init({ site: name });
+      }
+      opened = true;
+      cbInstance.openCheckout({
+        hostedPageUrl: page,
+        success: onSuccess,
+        close: onCancel,
       });
     };
     fn();
@@ -47,8 +33,16 @@ export const NewOrder: React.FC<{
       if (timer) {
         window.clearTimeout(timer);
       }
+      if (opened) {
+        try {
+          window.Chargebee?.getInstance()?.closeAll();
+        } catch {
+          // instance not ready / already closed
+        }
+      }
     };
   }, []);
 
-  return <div ref={ref} />;
+  // v2 renders the checkout in its own modal overlay, so nothing inline here.
+  return null;
 };

--- a/src/lib/window.d.ts
+++ b/src/lib/window.d.ts
@@ -8,7 +8,7 @@ export type GuesstimateWorker = Worker & {
 declare global {
   interface Window {
     workers: GuesstimateWorker[];
-    ChargeBee: any;
+    Chargebee: any;
     get_profile: () => any;
     _elev: any;
   }

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -35,7 +35,7 @@ const MyApp = ({ Component }: AppProps) => {
       _elev.account_id = '565e550e67ffc'`}</Script>
       <Script id="wistia" src="//fast.wistia.com/assets/external/E-v1.js" />
       <Script id="twitter">{`!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0],p=/^http:/.test(d.location)?'http':'https';if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src=p+"://platform.twitter.com/widgets.js";fjs.parentNode.insertBefore(js,fjs);}}(document,"script","twitter-wjs");`}</Script>
-      <Script id="chargebee" src="https://js.chargebee.com/v1/chargebee.js" />
+      <Script id="chargebee" src="https://js.chargebee.com/v2/chargebee.js" />
       <Script id="iubenda" src="//cdn.iubenda.com/iubenda.js" />
       <Head>
         <title key="title">Guesstimate</title>


### PR DESCRIPTION
## Problem
After the backend TLS fix (getguesstimate/guesstimate-server#251), the subscribe/checkout area showed "loading…" then went blank. Console:
```
Uncaught SyntaxError: "cb.loaded" is not valid JSON
  at messageChannel (chargebee.js:1:8110)
```
The app loads Chargebee's **legacy v1** client (`js.chargebee.com/v1/chargebee.js`). Chargebee no longer supports its hosted-page postMessage protocol, so the iframe never renders.

## Fix
Migrate to **Chargebee.js v2**:
- Load `js.chargebee.com/v2/chargebee.js`.
- `NewOrder` now calls `cbInstance.openCheckout({ hostedPageUrl })`, which renders Chargebee's own modal checkout. The backend already returns the hosted page URL, so **no API change** is needed.
- `window.ChargeBee` → `window.Chargebee`.

## Note
This changes the UX from an inline iframe to Chargebee's modal overlay (the current, supported pattern).

## Verification
- `first_subscription` Jest tests pass (20 examples).
- Types clean; needs a live check on the Vercel preview with a logged-in user.

🤖 Generated with [Claude Code](https://claude.com/claude-code)