### PR TITLE
Pass full hosted page object to Chargebee openCheckout

### DIFF
--- a/src/components/subscriptions/FirstSubscription/FirstSubscription.tsx
+++ b/src/components/subscriptions/FirstSubscription/FirstSubscription.tsx
@@ -7,7 +7,7 @@ import { NewOrder } from "./NewOrder";
 
 type Props = {
   flowStage: string;
-  iframeUrl: string;
+  hostedPage: any;
   iframeWebsiteName: string;
   onPaymentCancel(): void;
   onPaymentSuccess(): void;
@@ -54,11 +54,11 @@ export const FormFailure: React.FC = () => (
 export const FormSuccess: React.FC<
   Pick<
     Props,
-    "iframeUrl" | "iframeWebsiteName" | "onPaymentCancel" | "onPaymentSuccess"
+    "hostedPage" | "iframeWebsiteName" | "onPaymentCancel" | "onPaymentSuccess"
   >
-> = ({ iframeUrl, iframeWebsiteName, onPaymentCancel, onPaymentSuccess }) => (
+> = ({ hostedPage, iframeWebsiteName, onPaymentCancel, onPaymentSuccess }) => (
   <NewOrder
-    page={iframeUrl}
+    hostedPage={hostedPage}
     name={iframeWebsiteName}
     onSuccess={onPaymentSuccess}
     onCancel={onPaymentCancel}
@@ -67,13 +67,13 @@ export const FormSuccess: React.FC<
 export const TestFormSuccess: React.FC<
   Pick<
     Props,
-    "iframeUrl" | "iframeWebsiteName" | "onPaymentCancel" | "onPaymentSuccess"
+    "hostedPage" | "iframeWebsiteName" | "onPaymentCancel" | "onPaymentSuccess"
   >
-> = ({ iframeUrl, iframeWebsiteName, onPaymentCancel, onPaymentSuccess }) => (
+> = ({ hostedPage, iframeWebsiteName, onPaymentCancel, onPaymentSuccess }) => (
   <div>
     <h1 className="text-3xl">This is a test.</h1>
     <H2>Pretend strongly that there is a payment iframe here</H2>
-    <div>iframeUrl: {iframeUrl}</div>
+    <div>hostedPage: {JSON.stringify(hostedPage)}</div>
     <div>iframeWebsiteName: {iframeWebsiteName}</div>
     <Button color="red" onClick={onPaymentCancel}>
       Pretend to Cancel
@@ -111,14 +111,14 @@ export const FirstSubscription: React.FC<Props> = ({
   flowStage,
   onNewModel,
   isTest = true, // TODO - default to false?
-  iframeUrl = "",
+  hostedPage,
   iframeWebsiteName = "",
   onPaymentCancel,
   onPaymentSuccess,
   paymentAccountPortalUrl = "",
 }) => {
   const formSuccessProps = {
-    iframeUrl,
+    hostedPage,
     iframeWebsiteName,
     onPaymentCancel,
     onPaymentSuccess,

--- a/src/components/subscriptions/FirstSubscription/NewOrder.tsx
+++ b/src/components/subscriptions/FirstSubscription/NewOrder.tsx
@@ -1,11 +1,11 @@
 import { useEffect } from "react";
 
 export const NewOrder: React.FC<{
-  page: string;
+  hostedPage: any;
   name: string;
   onSuccess(): void;
   onCancel(): void;
-}> = ({ page, name, onSuccess, onCancel }) => {
+}> = ({ hostedPage, name, onSuccess, onCancel }) => {
   useEffect(() => {
     let timer: number | undefined;
     let opened = false;
@@ -22,8 +22,11 @@ export const NewOrder: React.FC<{
         cbInstance = window.Chargebee.init({ site: name });
       }
       opened = true;
+      // Pass the full hosted page object (not just its url) so the checkout
+      // runs in-context and fires `success` here, instead of redirecting away
+      // and losing the post-payment account sync.
       cbInstance.openCheckout({
-        hostedPageUrl: page,
+        hostedPage: () => Promise.resolve(hostedPage),
         success: onSuccess,
         close: onCancel,
       });

--- a/src/components/subscriptions/FirstSubscription/StyleGuide.tsx
+++ b/src/components/subscriptions/FirstSubscription/StyleGuide.tsx
@@ -8,7 +8,7 @@ import { FirstSubscription } from "./FirstSubscription";
 const FirstSubscriptionBaseProps = {
   planId: "small",
   paymentAccountPortalUrl: "http://foobar.com",
-  iframeUrl: "http://foobar.com",
+  hostedPage: { url: "http://foobar.com" },
   iframeWebsiteName: "good-stuff",
   onPaymentCancel: function (g) {
     console.log(g);

--- a/src/components/subscriptions/FirstSubscription/container.tsx
+++ b/src/components/subscriptions/FirstSubscription/container.tsx
@@ -37,7 +37,7 @@ export const FirstSubscriptionContainer: React.FC<Props> = ({ planId }) => {
     return null; // shouldn't happen, FirstSubscriptionPage won't render this component if user is not signed in
   }
 
-  const iframeUrl = firstSubscription.iframe?.href || "";
+  const hostedPage = firstSubscription.iframe?.hosted_page;
 
   const iframeWebsiteName = firstSubscription.iframe?.website_name || "";
 
@@ -62,7 +62,7 @@ export const FirstSubscriptionContainer: React.FC<Props> = ({ planId }) => {
     <FirstSubscription
       flowStage={flowStage}
       paymentAccountPortalUrl={paymentAccountPortalUrl}
-      iframeUrl={iframeUrl}
+      hostedPage={hostedPage}
       iframeWebsiteName={iframeWebsiteName}
       onPaymentSuccess={handlePaymentSuccess}
       onPaymentCancel={handlePaymentCancel}

--- a/src/modules/first_subscription/reducer.ts
+++ b/src/modules/first_subscription/reducer.ts
@@ -6,7 +6,7 @@ import { newFlowState } from "./state_machine";
 export const initialState = {
   flowStage: "START",
   iframe: {
-    href: null,
+    hosted_page: null,
     website_name: null,
     request: initialRequestState,
   },
@@ -28,11 +28,11 @@ const iframe: Reducer<any> = (
 ) => {
   switch (action.type) {
     case "FIRST_SUBSCRIPTION_IFRAME_FETCH_START":
-      return singleEntity(state, action, "START", ["href", "website_name"]);
+      return singleEntity(state, action, "START", ["hosted_page", "website_name"]);
     case "FIRST_SUBSCRIPTION_IFRAME_FETCH_SUCCESS":
-      return singleEntity(state, action, "SUCCESS", ["href", "website_name"]);
+      return singleEntity(state, action, "SUCCESS", ["hosted_page", "website_name"]);
     case "FIRST_SUBSCRIPTION_IFRAME_FETCH_FAILURE":
-      return singleEntity(state, action, "FAILURE", ["href", "website_name"]);
+      return singleEntity(state, action, "FAILURE", ["hosted_page", "website_name"]);
     default:
       return state;
   }


### PR DESCRIPTION
Follow-up to #1061. Passing `hostedPageUrl` makes Chargebee redirect after payment, so the `success` callback never fires and the account is never synced (user stays on free after a real charge in prod).

This passes the full hosted page object via `openCheckout`'s `hostedPage` callback, which keeps checkout in-context and fires `success`/`close`.

Requires getguesstimate/guesstimate-server#252 (backend returns the object) to be deployed first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)