### PR TITLE
Fix subscribe page for users with a payment account

### DIFF
--- a/src/components/layout/Header/ProfileDropdown.tsx
+++ b/src/components/layout/Header/ProfileDropdown.tsx
@@ -16,7 +16,6 @@ import * as navigationActions from "~/modules/navigation/actions";
 export const ProfileDropdown: FC<{
   profile: MeProfile;
 }> = ({ profile }) => {
-  const portalUrl = _.get(profile, "account._links.payment_portal.href");
   const router = useRouter();
   const dispatch = useAppDispatch();
 
@@ -74,7 +73,8 @@ export const ProfileDropdown: FC<{
     },
   ];
 
-  if (!!portalUrl) {
+  const planId = _.get(profile, "plan.id");
+  if (planId && planId !== "personal_free") {
     listElements = listElements.filter((e) => e.header !== "upgrade");
   }
 

--- a/src/components/subscriptions/FirstSubscription/container.tsx
+++ b/src/components/subscriptions/FirstSubscription/container.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from "react";
+import { useEffect, useRef } from "react";
 
 import _ from "lodash";
 import { useRouter } from "next/router";
@@ -20,10 +20,23 @@ export const FirstSubscriptionContainer: React.FC<Props> = ({ planId }) => {
   const me = useAppSelector((state) => state.me);
   const firstSubscription = useAppSelector((state) => state.firstSubscription);
 
-  useEffect(() => {
-    dispatch(firstSubscriptionActions.flowStageReset());
+  // The profile arrives in two steps; only the second (authenticated) fetch
+  // includes plan.id. Wait for it, then decide once.
+  const profilePlanId = _.get(me, "profile.plan.id");
+  const initialized = useRef(false);
 
-    if (me.profile && !me.profile?.has_payment_account) {
+  useEffect(() => {
+    if (initialized.current || !profilePlanId || !me.profile) {
+      return;
+    }
+    initialized.current = true;
+
+    dispatch(firstSubscriptionActions.flowStageReset());
+    if (profilePlanId !== "personal_free") {
+      // Already on a paid plan: point to the portal instead of fetching a
+      // checkout the backend would refuse.
+      dispatch(firstSubscriptionActions.flowStageUnnecessary());
+    } else {
       dispatch(
         firstSubscriptionActions.fetchIframe({
           user_id: me.profile.id,
@@ -31,7 +44,7 @@ export const FirstSubscriptionContainer: React.FC<Props> = ({ planId }) => {
         })
       );
     }
-  }, []);
+  }, [profilePlanId]);
 
   if (!me.profile) {
     return null; // shouldn't happen, FirstSubscriptionPage won't render this component if user is not signed in
@@ -43,7 +56,10 @@ export const FirstSubscriptionContainer: React.FC<Props> = ({ planId }) => {
 
   const flowStage = subStage(firstSubscription);
 
-  const paymentAccountPortalUrl = _.get(me, "profile.account._links.account");
+  const paymentAccountPortalUrl = _.get(
+    me,
+    "profile.account._links.payment_portal.href"
+  );
 
   const handlePaymentSuccess = () => {
     dispatch(

--- a/src/components/users/settings/Settings.tsx
+++ b/src/components/users/settings/Settings.tsx
@@ -48,18 +48,21 @@ const PlanUpgradeSection: React.FC<{
   onRefresh?(): void;
 }> = ({ planId, portalUrl, onRefresh }) => {
   const hasPortalUrl = !!portalUrl;
+  // Free-plan users always get an upgrade button, even when they have a
+  // payment account from an earlier (cancelled) subscription.
+  const canUpgrade = planId === "personal_free";
   if (planId === "personal_infinite") {
     return null;
   } else {
     return (
       <div>
         <HR />
-        <div className="mt-8 flex flex-col items-center">
-          {hasPortalUrl ? (
+        <div className="mt-8 flex flex-col items-center space-y-4">
+          {canUpgrade && <PlanUpgradeButton />}
+          {hasPortalUrl && (
             <PortalButton url={portalUrl} onRefresh={onRefresh} />
-          ) : (
-            <PlanUpgradeButton />
           )}
+          {!canUpgrade && !hasPortalUrl && <PlanUpgradeButton />}
         </div>
       </div>
     );

--- a/src/modules/first_subscription/actions.ts
+++ b/src/modules/first_subscription/actions.ts
@@ -68,6 +68,10 @@ export function flowStageReset() {
   return { type: "FIRST_SUBSCRIPTION_FLOW_RESET" };
 }
 
+export function flowStageUnnecessary() {
+  return { type: "FIRST_SUBSCRIPTION_FLOW_UNNECESSARY" };
+}
+
 export function flowStageCancel() {
   return { type: "FIRST_SUBSCRIPTION_FLOW_CANCEL" };
 }


### PR DESCRIPTION
Companion to the server webhooks/re-subscribe PR.

- Gate the upgrade button on plan (free) instead of on having a payment account, so users with a cancelled subscription can subscribe again; settings shows both Upgrade and the portal button.
- `/subscribe/*` shows the portal message for users already on a paid plan instead of hanging on "Loading…".
- Wait for the full profile (plan.id arrives only with the second, authenticated fetch) before deciding; use the `payment_portal` link instead of the broken `_links.account` path.

Requires the guesstimate-server PR to be deployed first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)