### PR TITLE
Sync account when landing from a Chargebee checkout redirect

### DIFF
--- a/src/components/layout/CheckoutRedirectSync.tsx
+++ b/src/components/layout/CheckoutRedirectSync.tsx
@@ -1,0 +1,38 @@
+import { FC, useEffect, useRef } from "react";
+
+import { useRouter } from "next/router";
+import * as firstSubscriptionActions from "~/modules/first_subscription/actions";
+import { useAppDispatch, useAppSelector } from "~/modules/hooks";
+
+// Chargebee's hosted checkout can be configured (site-wide) to redirect back
+// to the app with `?id=<hosted_page_id>&state=succeeded` instead of staying
+// in the popup. In that case the popup success callback never fires, so we
+// sync the account here when we land on such a URL.
+export const CheckoutRedirectSync: FC = () => {
+  const router = useRouter();
+  const dispatch = useAppDispatch();
+  const profileId = useAppSelector((state) => state.me.profile?.id);
+  const synced = useRef(false);
+
+  useEffect(() => {
+    if (synced.current || !router.isReady || !profileId) {
+      return;
+    }
+    if (router.query.state !== "succeeded") {
+      return;
+    }
+    synced.current = true;
+
+    dispatch(
+      firstSubscriptionActions.postSynchronization({ user_id: profileId })
+    );
+
+    // Drop the checkout params so a reload doesn't re-sync.
+    const { id, state, ...query } = router.query;
+    router.replace({ pathname: router.pathname, query }, undefined, {
+      shallow: true,
+    });
+  }, [router.isReady, profileId]);
+
+  return null;
+};

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -11,6 +11,7 @@ import Head from "next/head";
 import Script from "next/script";
 import { Provider } from "react-redux";
 import { AuthProvider } from "~/components/layout/AuthProvider";
+import { CheckoutRedirectSync } from "~/components/layout/CheckoutRedirectSync";
 
 import { configureStore } from "../modules/store";
 
@@ -47,7 +48,14 @@ const MyApp = ({ Component }: AppProps) => {
       {/* no session here - it's loaded on client side */}
       <SessionProvider>
         <Provider store={store}>
-          <AuthProvider>{isClient ? <Component /> : null}</AuthProvider>
+          <AuthProvider>
+            {isClient ? (
+              <>
+                <CheckoutRedirectSync />
+                <Component />
+              </>
+            ) : null}
+          </AuthProvider>
         </Provider>
       </SessionProvider>
     </>


### PR DESCRIPTION
Prod Chargebee redirects back to the app with `?id=...&state=succeeded` instead of keeping checkout in the popup, so the popup success callback (which syncs the account) never fires — the user lands on the homepage still showing the old plan until the webhook lands and they fully reload.

This detects the redirect on any page, posts an account synchronization (which also reloads the profile), and strips the checkout params from the URL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)